### PR TITLE
emit slot stats even if getpayload not received

### DIFF
--- a/service.go
+++ b/service.go
@@ -1644,13 +1644,12 @@ func (s *Service) EmitSlotStats(ctx context.Context) {
 				defer timer.Stop()
 				select {
 				case <-timer.C:
-					isVouch := isVouch(event.UserAgent)
 					v, ok := s.slotStatsEvent.Get(event.SlotKey)
 					if ok { //Populated when getPayloadOnly is called
 						record, success := v.(SlotStatsRecord)
 						if success {
 							s.logRecord(record, event.SlotKey, event.UserAgent)
-						} else if isVouch {
+						} else {
 							slotStats, found := s.slotStats.Get(event.SlotKey)
 							if found {
 								if records, slotStatsSuccess := slotStats.([]SlotStatsRecord); slotStatsSuccess {
@@ -1659,7 +1658,7 @@ func (s *Service) EmitSlotStats(ctx context.Context) {
 								}
 							}
 						}
-					} else if isVouch {
+					} else {
 						slotStats, found := s.slotStats.Get(event.SlotKey)
 						if found {
 							if records, slotStatsSuccess := slotStats.([]SlotStatsRecord); slotStatsSuccess {


### PR DESCRIPTION
## 📝 Summary

-  Emit slot stats event even if getpyaload not received.  This is to support latest MEVBoost1.9 changes.This PR will be reverted once MEVBoost remove this changes in the version

## 💡 Motivation and Context

<!--- (Optional) Why is this change required? What problem does it solve? Remove this section if not applicable. -->

---

## ✅ I have completed the following steps:

* [ ] Run `make lint`
* [ ] Run `make test`
* [ ] Run `go mod tidy`
* [ ] Added tests (if applicable)
