### PR TITLE
Fast IP Switchover

### DIFF
--- a/cmd/relayproxy/main.go
+++ b/cmd/relayproxy/main.go
@@ -20,7 +20,6 @@ import (
 	"time"
 
 	"github.com/attestantio/go-eth2-client/spec/phase0"
-	relaygrpc "github.com/bloXroute-Labs/relay-grpc"
 	"github.com/bloXroute-Labs/relayproxy"
 	"github.com/bloXroute-Labs/relayproxy/common"
 	"github.com/bloXroute-Labs/relayproxy/fluentstats"
@@ -145,18 +144,18 @@ func main() {
 
 	// init client connection
 	var (
-		clients []*common.Client
+		clients []*common.ParentClient
 		conns   []*grpc.ClientConn
 
-		streamingClients []*common.Client
+		streamingClients []*common.ParentClient
 		streamingConns   []*grpc.ClientConn
 
-		registrationClients []*common.Client
+		registrationClients []*common.ParentClient
 		regConns            []*grpc.ClientConn
 	)
 
 	// Parse the relaysGRPCURL
-	newClients, newConns := getClientsAndConnsFromURLs(l, *relaysGRPCURL, conns, keepaliveOpts, clients)
+	newClients, newConns := getClientsAndConnsFromURLs(l, *relaysGRPCURL, conns, keepaliveOpts, clients, map[string]string{})
 	defer func() {
 		for _, conn := range newConns {
 			conn.Close()
@@ -164,7 +163,7 @@ func main() {
 	}()
 
 	// Parse the streamingRelaysGRPCURL
-	newStreamingClients, newStreamingConns := getClientsAndConnsFromURLs(l, *streamingRelaysGRPCURL, streamingConns, keepaliveOpts, streamingClients)
+	newStreamingClients, newStreamingConns := getClientsAndConnsFromURLs(l, *streamingRelaysGRPCURL, streamingConns, keepaliveOpts, streamingClients, map[string]string{})
 	defer func() {
 		for _, conn := range newStreamingConns {
 			conn.Close()
@@ -172,7 +171,7 @@ func main() {
 	}()
 
 	// Parse the registrationRelaysURL
-	newRegistrationClients, newRegConns := getClientsAndConnsFromURLs(l, *registrationRelaysGRPCURL, regConns, keepaliveOpts, registrationClients)
+	newRegistrationClients, newRegConns := getClientsAndConnsFromURLs(l, *registrationRelaysGRPCURL, regConns, keepaliveOpts, registrationClients, map[string]string{})
 	defer func() {
 		for _, conn := range newRegConns {
 			conn.Close()
@@ -478,7 +477,7 @@ func getEnv(key string, defaultValue string) string {
 	return defaultValue
 }
 
-func getClientsAndConnsFromURLs(l zerolog.Logger, relaysGRPCURL string, conns []*grpc.ClientConn, keepaliveOpts grpc.DialOption, clients []*common.Client) ([]*common.Client, []*grpc.ClientConn) {
+func getClientsAndConnsFromURLs(l zerolog.Logger, relaysGRPCURL string, conns []*grpc.ClientConn, keepaliveOpts grpc.DialOption, clients []*common.ParentClient, fastAlternativeIPMapping map[string]string) ([]*common.ParentClient, []*grpc.ClientConn) {
 	// Parse the relaysGRPCURL
 	relays := strings.Split(relaysGRPCURL, ",")
 	// Dial each relay and store the connections
@@ -499,7 +498,35 @@ func getClientsAndConnsFromURLs(l zerolog.Logger, relaysGRPCURL string, conns []
 			continue
 		}
 		conns = append(conns, conn)
-		clients = append(clients, &common.Client{URL: relayURL, RelayClient: relaygrpc.NewRelayClient(conn)})
+		var (
+			fastUrl  string
+			fastConn *grpc.ClientConn
+			found    bool
+		)
+		fastUrl, found = fastAlternativeIPMapping[relayURL]
+		if found {
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+			fastConn, err = grpc.DialContext( //nolint:staticcheck
+				ctx,
+				fastUrl,
+				grpc.WithTransportCredentials(insecure.NewCredentials()),
+				keepaliveOpts,
+				grpc.WithInitialConnWindowSize(windowSize),
+				grpc.WithWriteBufferSize(bufferSize),
+			)
+
+			cancel()
+			if err != nil {
+				// Handle error: failed to dial relay
+				l.Err(err).Str("url", relayURL).Msg("failed to dial relay")
+				continue
+			}
+			conns = append(conns, fastConn)
+		} else {
+			fastUrl = relayURL
+			fastConn = conn
+		}
+		clients = append(clients, common.NewParentClient(relayURL, conn, fastUrl, fastConn))
 	}
 	if len(conns) == 0 {
 		l.Fatal().Msg("failed to create grpc connection")

--- a/common/types.go
+++ b/common/types.go
@@ -301,8 +301,25 @@ func (r *VersionedSignedBlindedBeaconBlock) ExecutionParentHash() (phase0.Hash32
 type Client struct {
 	URL    string
 	NodeID string
-	Conn   *grpc.ClientConn
 	relaygrpc.RelayClient
+}
+
+type ParentClient struct {
+	FastClient *Client
+	SafeClient *Client
+}
+
+func NewParentClient(safeUrl string, safeConn *grpc.ClientConn, fastUrl string, fastConn *grpc.ClientConn) *ParentClient {
+	return &ParentClient{
+		FastClient: &Client{
+			URL:         fastUrl,
+			RelayClient: relaygrpc.NewRelayClient(fastConn),
+		},
+		SafeClient: &Client{
+			URL:         safeUrl,
+			RelayClient: relaygrpc.NewRelayClient(fastConn),
+		},
+	}
 }
 
 type Bid struct {
@@ -313,7 +330,7 @@ type Bid struct {
 	BuilderPubkey      string
 	BuilderExtraData   string
 	AccountID          string
-	Client             *Client
+	Client             *ParentClient
 	PayloadFetchUrl    string
 }
 
@@ -324,7 +341,7 @@ func NewBid(Value []byte,
 	builderPubkey string,
 	builderExtraData string,
 	accountID string,
-	client *Client,
+	client *ParentClient,
 	payloadFetchUrl string,
 ) *Bid {
 	return &Bid{

--- a/common/types.go
+++ b/common/types.go
@@ -311,11 +311,15 @@ type ParentClient struct {
 	SafeClient *Client
 }
 
-func (p *ParentClient) GetActiveClient(lastConnectTime time.Time) *Client {
+func (p *ParentClient) String() string {
+	return fmt.Sprintf("ParentClient{FastClient: %s, SafeClient: %s}", p.FastClient.URL, p.SafeClient.URL)
+}
+
+func (p *ParentClient) GetActiveClient(lastConnectTime time.Time) (*Client, bool) {
 	if time.Since(lastConnectTime) <= clientFailureWindow {
-		return p.SafeClient
+		return p.SafeClient, true
 	}
-	return p.FastClient
+	return p.FastClient, false
 }
 
 func NewParentClient(safeUrl string, safeConn *grpc.ClientConn, fastUrl string, fastConn *grpc.ClientConn) *ParentClient {

--- a/common/types.go
+++ b/common/types.go
@@ -298,6 +298,8 @@ func (r *VersionedSignedBlindedBeaconBlock) ExecutionParentHash() (phase0.Hash32
 	}
 }
 
+var clientFailureWindow = time.Minute * 10
+
 type Client struct {
 	URL    string
 	NodeID string
@@ -307,6 +309,13 @@ type Client struct {
 type ParentClient struct {
 	FastClient *Client
 	SafeClient *Client
+}
+
+func (p *ParentClient) GetActiveClient(lastConnectTime time.Time) *Client {
+	if time.Since(lastConnectTime) <= clientFailureWindow {
+		return p.SafeClient
+	}
+	return p.FastClient
 }
 
 func NewParentClient(safeUrl string, safeConn *grpc.ClientConn, fastUrl string, fastConn *grpc.ClientConn) *ParentClient {

--- a/common/types.go
+++ b/common/types.go
@@ -330,7 +330,7 @@ func NewParentClient(safeUrl string, safeConn *grpc.ClientConn, fastUrl string, 
 		},
 		SafeClient: &Client{
 			URL:         safeUrl,
-			RelayClient: relaygrpc.NewRelayClient(fastConn),
+			RelayClient: relaygrpc.NewRelayClient(safeConn),
 		},
 	}
 }

--- a/opts.go
+++ b/opts.go
@@ -203,19 +203,19 @@ func WithEthNetworkDetails(details *common.EthNetworkDetails) ServiceOption {
 	}
 }
 
-func WithClients(clients []*common.Client) ServiceOption {
+func WithClients(clients []*common.ParentClient) ServiceOption {
 	return func(s *Service) {
 		s.clients = clients
 	}
 }
 
-func WithStreamingClients(clients []*common.Client) ServiceOption {
+func WithStreamingClients(clients []*common.ParentClient) ServiceOption {
 	return func(s *Service) {
 		s.streamingClients = clients
 	}
 }
 
-func WithRegistrationClients(clients []*common.Client) ServiceOption {
+func WithRegistrationClients(clients []*common.ParentClient) ServiceOption {
 	return func(s *Service) {
 		s.registrationClients = clients
 	}
@@ -227,7 +227,7 @@ func WithCurrentRegistrationRelayIndex(index int) ServiceOption {
 	}
 }
 
-func WithStreamingBlockClients(clients []*common.Client) ServiceOption {
+func WithStreamingBlockClients(clients []*common.ParentClient) ServiceOption {
 	return func(s *Service) {
 		s.streamingBlockClients = clients
 	}

--- a/service.go
+++ b/service.go
@@ -58,6 +58,8 @@ const (
 	reconnectTime                     = 6000
 
 	prefetchAttempts = 20
+
+	clientFailureWindow = time.Minute * 10
 )
 
 var (
@@ -97,10 +99,10 @@ type Service struct {
 	slotStatsEventCh   chan slotStatsEvent
 	ethNetworkDetails  *common.EthNetworkDetails
 
-	clients                       []*common.Client
-	streamingClients              []*common.Client
-	streamingBlockClients         []*common.Client
-	registrationClients           []*common.Client
+	clients                       []*common.ParentClient
+	streamingClients              []*common.ParentClient
+	streamingBlockClients         []*common.ParentClient
+	registrationClients           []*common.ParentClient
 	currentRegistrationRelayIndex int
 	registrationRelayMutex        sync.Mutex
 
@@ -136,7 +138,7 @@ type preFetcherFields struct {
 	proposerPubKey  string
 	builderPubKey   string
 	blockValue      string
-	client          *common.Client
+	client          *common.ParentClient
 	payloadFetchUrl string
 }
 
@@ -268,8 +270,8 @@ func (s *Service) registerValidatorForClient(_ctx context.Context, req *relaygrp
 		s.currentRegistrationRelayIndex = (s.currentRegistrationRelayIndex + 1) % len(s.registrationClients)
 		s.registrationRelayMutex.Unlock()
 
-		out, err = selectedRelay.RegisterValidator(_ctx, req)
-		url := selectedRelay.URL
+		out, err = selectedRelay.SafeClient.RegisterValidator(_ctx, req)
+		url := selectedRelay.SafeClient.URL
 
 		if err != nil || out == nil || out.Code != uint32(codes.OK) {
 			s.logger.Warn().Str("url", url).Err(err).Msg("failed to register validator")
@@ -315,7 +317,7 @@ func (s *Service) StartStreamHeaders(ctx context.Context, wg *sync.WaitGroup) {
 
 	for _, client := range s.streamingClients {
 		wg.Add(1)
-		go func(_ctx context.Context, c *common.Client) {
+		go func(_ctx context.Context, c *common.ParentClient) {
 			defer wg.Done()
 			s.handleStream(_ctx, c)
 		}(ctx, client)
@@ -323,7 +325,7 @@ func (s *Service) StartStreamHeaders(ctx context.Context, wg *sync.WaitGroup) {
 	wg.Wait()
 }
 
-func (s *Service) handleStream(ctx context.Context, client *common.Client) {
+func (s *Service) handleStream(ctx context.Context, client *common.ParentClient) {
 	parentSpan := trace.SpanFromContext(ctx)
 	ctx = trace.ContextWithSpan(context.Background(), parentSpan)
 	_, span := s.tracer.Start(ctx, "handleStream-streamHeader")
@@ -333,11 +335,16 @@ func (s *Service) handleStream(ctx context.Context, client *common.Client) {
 
 	span.SetAttributes(
 		attribute.String("method", "streamHeader"),
-		attribute.String("url", client.URL),
+		attribute.String("url", client.SafeClient.URL),
 		attribute.String("traceID", traceID),
 	)
 
+	var (
+		lastConnectTime time.Time
+	)
+
 	for {
+
 		select {
 		case <-ctx.Done():
 			s.logger.Warn().
@@ -346,9 +353,15 @@ func (s *Service) handleStream(ctx context.Context, client *common.Client) {
 			return
 
 		default:
-			if _, err := s.StreamHeader(ctx, client); err != nil {
+			active := client.FastClient
+			if time.Since(lastConnectTime) <= clientFailureWindow {
+				active = client.SafeClient
+			}
+			lastConnectTime = time.Now()
+
+			if _, err := s.StreamHeader(ctx, active, client); err != nil {
 				s.logger.Warn().
-					Str("url", client.URL).
+					Str("url", active.URL).
 					Str("traceID", traceID).
 					Err(err).
 					Msg("failed to stream header. Sleeping and then reconnecting")
@@ -359,7 +372,7 @@ func (s *Service) handleStream(ctx context.Context, client *common.Client) {
 				)
 			} else {
 				s.logger.Warn().
-					Str("url", client.URL).
+					Str("url", active.URL).
 					Str("traceID", traceID).
 					Msg("stream header stopped. Sleeping and then reconnecting")
 
@@ -374,7 +387,7 @@ func (s *Service) handleStream(ctx context.Context, client *common.Client) {
 	}
 }
 
-func (s *Service) StreamHeader(ctx context.Context, client *common.Client) (*relaygrpc.StreamHeaderResponse, error) {
+func (s *Service) StreamHeader(ctx context.Context, client *common.Client, parentClient *common.ParentClient) (*relaygrpc.StreamHeaderResponse, error) {
 	parentSpan := trace.SpanFromContext(ctx)
 	method := "streamHeader"
 	ctx = trace.ContextWithSpan(context.Background(), parentSpan)
@@ -616,7 +629,7 @@ func (s *Service) StreamHeader(ctx context.Context, client *common.Client) (*rel
 			header.GetBuilderPubkey(),
 			header.GetBuilderExtraData(),
 			header.GetAccountId(),
-			client,
+			parentClient,
 			header.GetPayloadFetchUrl(),
 		)
 		s.setBuilderBidForProxySlot(k, header.GetBuilderPubkey(), bid, header.GetSlot())
@@ -920,7 +933,7 @@ func (s *Service) PreFetchGetPayload(ctx context.Context, fields preFetcherField
 	defer span.End(trace.WithTimestamp(time.Now()))
 
 	if fields.client != nil {
-		clientURL = fields.client.URL
+		clientURL = fields.client.SafeClient.URL
 	}
 
 	uKey := fmt.Sprintf("slot_%v_bHash_%v_pHash_%v", fields.slot, fields.blockHash, fields.parentHash)
@@ -1038,10 +1051,10 @@ func (s *Service) prefetchPayloadGRPC(
 		prefetchedRequests += len(clients)
 		for _, client := range clients {
 			wg.Add(1)
-			go func(client *common.Client) {
+			go func(client *common.ParentClient) {
 				defer wg.Done()
 				prefetchLogger := s.logger.With().Fields(logMetric.GetFields()).Logger()
-				s.prefetchPayload(ctx, client, req, span, errChan, respChan, prefetchLogger)
+				s.prefetchPayload(ctx, client.SafeClient, req, span, errChan, respChan, prefetchLogger)
 			}(client)
 		}
 	}
@@ -1483,9 +1496,9 @@ func (s *Service) GetPayload(ctx context.Context, in *PayloadRequestParams) (any
 	ctx, payloadResponseSpan := s.tracer.Start(ctx, "getPayload-payloadResponseFromRelay")
 	for _, client := range s.clients {
 		wg.Add(1)
-		go func(c *common.Client) {
+		go func(c *common.ParentClient) {
 			defer wg.Done()
-			out, err := s.getPayloadWithRetry(ctx, c, span, req, maxGetPayloadRetry)
+			out, err := s.getPayloadWithRetry(ctx, c.SafeClient, span, req, maxGetPayloadRetry)
 			if err != nil {
 				s.logger.Error().Err(err).Msg("getPayloadWithRetry")
 				errChan <- ErrorRespWithPayload{err: err, resp: out}
@@ -1907,7 +1920,7 @@ func (s *Service) EmitSlotStats(ctx context.Context) {
 func (s *Service) StartStreamBlocks(ctx context.Context, wg *sync.WaitGroup) {
 	for _, client := range s.streamingBlockClients {
 		wg.Add(1)
-		go func(_ctx context.Context, c *common.Client) {
+		go func(_ctx context.Context, c *common.ParentClient) {
 			defer wg.Done()
 			s.handleBlockStream(_ctx, c)
 		}(ctx, client)
@@ -1916,7 +1929,7 @@ func (s *Service) StartStreamBlocks(ctx context.Context, wg *sync.WaitGroup) {
 	wg.Wait()
 }
 
-func (s *Service) handleBlockStream(ctx context.Context, client *common.Client) {
+func (s *Service) handleBlockStream(ctx context.Context, client *common.ParentClient) {
 	parentSpan := trace.SpanFromContext(ctx)
 	ctx = trace.ContextWithSpan(context.Background(), parentSpan)
 	_, span := s.tracer.Start(ctx, "handleBlockStream-streamBlock")
@@ -1926,9 +1939,11 @@ func (s *Service) handleBlockStream(ctx context.Context, client *common.Client) 
 
 	span.SetAttributes(
 		attribute.String("method", "streamBlock"),
-		attribute.String("url", client.URL),
+		attribute.String("url", client.SafeClient.URL),
 		attribute.String("traceID", traceID),
 	)
+
+	var lastConnectTime time.Time
 
 	for {
 		select {
@@ -1938,9 +1953,14 @@ func (s *Service) handleBlockStream(ctx context.Context, client *common.Client) 
 				Msg("stream block context cancelled")
 			return
 		default:
-			if _, err := s.StreamBlock(ctx, client); err != nil {
+			active := client.FastClient
+			if time.Since(lastConnectTime) <= clientFailureWindow {
+				active = client.SafeClient
+			}
+			lastConnectTime = time.Now()
+			if _, err := s.StreamBlock(ctx, active); err != nil {
 				s.logger.Warn().
-					Str("url", client.URL).
+					Str("url", active.URL).
 					Str("traceID", traceID).
 					Err(err).
 					Msg("failed to stream block. Sleeping and then reconnecting")
@@ -1951,7 +1971,7 @@ func (s *Service) handleBlockStream(ctx context.Context, client *common.Client) 
 				)
 			} else {
 				s.logger.Warn().
-					Str("url", client.URL).
+					Str("url", active.URL).
 					Str("traceID", traceID).
 					Msg("stream block stopped. Sleeping and then reconnecting")
 
@@ -2097,7 +2117,7 @@ func (s *Service) StreamBlock(ctx context.Context, client *common.Client) (*rela
 func (s *Service) handleForwardedBlockResponse() {
 	s.logger.Info().Msg("start handling forwarded block response")
 	for forwardedBlockInfo := range *s.forwardedBlockCh {
-		s.logger.Info().Msg("received forwarded block from channel")
+		// s.logger.Info().Msg("received forwarded block from channel")
 
 		lm := NewLogMetric(
 			map[string]any{
@@ -2392,18 +2412,19 @@ func isVouch(userAgent string) bool {
 func (s *Service) StartStreamBuilderInfo(ctx context.Context, wg *sync.WaitGroup) {
 	for _, client := range s.streamingBlockClients {
 		wg.Add(1)
-		go func(_ctx context.Context, c *common.Client) {
+		go func(_ctx context.Context, c *common.ParentClient) {
 			defer wg.Done()
 			s.handleBuilderInfoStream(_ctx, c)
 		}(ctx, client)
 	}
 	wg.Wait()
 }
-func (s *Service) handleBuilderInfoStream(ctx context.Context, client *common.Client) {
+func (s *Service) handleBuilderInfoStream(ctx context.Context, client *common.ParentClient) {
 	parentSpan := trace.SpanFromContext(ctx)
 	ctx = trace.ContextWithSpan(context.Background(), parentSpan)
 	traceID := parentSpan.SpanContext().TraceID().String()
 
+	var lastConnectTime time.Time
 	for {
 		select {
 		case <-ctx.Done():
@@ -2412,15 +2433,21 @@ func (s *Service) handleBuilderInfoStream(ctx context.Context, client *common.Cl
 				Msg("stream block context cancelled")
 			return
 		default:
-			if _, err := s.StreamBuilderInfo(ctx, client); err != nil {
+			active := client.FastClient
+			if time.Since(lastConnectTime) <= clientFailureWindow {
+				active = client.SafeClient
+			}
+			lastConnectTime = time.Now()
+
+			if _, err := s.StreamBuilderInfo(ctx, active); err != nil {
 				s.logger.Warn().
-					Str("url", client.URL).
+					Str("url", active.URL).
 					Str("traceID", traceID).
 					Err(err).
 					Msg("failed to stream builderInfo. Sleeping and then reconnecting")
 			} else {
 				s.logger.Warn().
-					Str("url", client.URL).
+					Str("url", active.URL).
 					Str("traceID", traceID).
 					Msg("stream builderInfo stopped. Sleeping and then reconnecting")
 			}
@@ -2869,18 +2896,19 @@ func (s *Service) PreFetchGetPayloadPlaceHTTPRequest(ctx context.Context, origRe
 func (s *Service) StartStreamSlotInfo(ctx context.Context, wg *sync.WaitGroup) {
 	for _, client := range s.streamingBlockClients {
 		wg.Add(1)
-		go func(_ctx context.Context, c *common.Client) {
+		go func(_ctx context.Context, c *common.ParentClient) {
 			defer wg.Done()
 			s.handleSlotInfoStream(_ctx, c)
 		}(ctx, client)
 	}
 	wg.Wait()
 }
-func (s *Service) handleSlotInfoStream(ctx context.Context, client *common.Client) {
+func (s *Service) handleSlotInfoStream(ctx context.Context, client *common.ParentClient) {
 	parentSpan := trace.SpanFromContext(ctx)
 	ctx = trace.ContextWithSpan(context.Background(), parentSpan)
 	traceID := parentSpan.SpanContext().TraceID().String()
 
+	var lastConnectTime time.Time
 	for {
 		select {
 		case <-ctx.Done():
@@ -2889,15 +2917,21 @@ func (s *Service) handleSlotInfoStream(ctx context.Context, client *common.Clien
 				Msg("stream block context cancelled")
 			return
 		default:
-			if _, err := s.StreamSlotInfo(ctx, client); err != nil {
+			active := client.FastClient
+			if time.Since(lastConnectTime) <= clientFailureWindow {
+				active = client.SafeClient
+			}
+			lastConnectTime = time.Now()
+
+			if _, err := s.StreamSlotInfo(ctx, active); err != nil {
 				s.logger.Warn().
-					Str("url", client.URL).
+					Str("url", active.URL).
 					Str("traceID", traceID).
 					Err(err).
 					Msg("failed to stream SlotInfo. Sleeping and then reconnecting")
 			} else {
 				s.logger.Warn().
-					Str("url", client.URL).
+					Str("url", active.URL).
 					Str("traceID", traceID).
 					Msg("stream SlotInfo stopped. Sleeping and then reconnecting")
 			}

--- a/service.go
+++ b/service.go
@@ -58,8 +58,6 @@ const (
 	reconnectTime                     = 6000
 
 	prefetchAttempts = 20
-
-	clientFailureWindow = time.Minute * 10
 )
 
 var (
@@ -353,10 +351,8 @@ func (s *Service) handleStream(ctx context.Context, client *common.ParentClient)
 			return
 
 		default:
-			active := client.FastClient
-			if time.Since(lastConnectTime) <= clientFailureWindow {
-				active = client.SafeClient
-			}
+
+			active := client.GetActiveClient(lastConnectTime)
 			lastConnectTime = time.Now()
 
 			if _, err := s.StreamHeader(ctx, active, client); err != nil {
@@ -1953,10 +1949,7 @@ func (s *Service) handleBlockStream(ctx context.Context, client *common.ParentCl
 				Msg("stream block context cancelled")
 			return
 		default:
-			active := client.FastClient
-			if time.Since(lastConnectTime) <= clientFailureWindow {
-				active = client.SafeClient
-			}
+			active := client.GetActiveClient(lastConnectTime)
 			lastConnectTime = time.Now()
 			if _, err := s.StreamBlock(ctx, active); err != nil {
 				s.logger.Warn().
@@ -2433,10 +2426,7 @@ func (s *Service) handleBuilderInfoStream(ctx context.Context, client *common.Pa
 				Msg("stream block context cancelled")
 			return
 		default:
-			active := client.FastClient
-			if time.Since(lastConnectTime) <= clientFailureWindow {
-				active = client.SafeClient
-			}
+			active := client.GetActiveClient(lastConnectTime)
 			lastConnectTime = time.Now()
 
 			if _, err := s.StreamBuilderInfo(ctx, active); err != nil {
@@ -2917,10 +2907,7 @@ func (s *Service) handleSlotInfoStream(ctx context.Context, client *common.Paren
 				Msg("stream block context cancelled")
 			return
 		default:
-			active := client.FastClient
-			if time.Since(lastConnectTime) <= clientFailureWindow {
-				active = client.SafeClient
-			}
+			active := client.GetActiveClient(lastConnectTime)
 			lastConnectTime = time.Now()
 
 			if _, err := s.StreamSlotInfo(ctx, active); err != nil {

--- a/service.go
+++ b/service.go
@@ -352,7 +352,10 @@ func (s *Service) handleStream(ctx context.Context, client *common.ParentClient)
 
 		default:
 
-			active := client.GetActiveClient(lastConnectTime)
+			active, safe := client.GetActiveClient(lastConnectTime)
+			if safe {
+				s.logger.Warn().Str("method", "streamHeader").Str("fastURL", client.FastClient.URL).Str("safeURL", client.SafeClient.URL).Msg("Fallback to safe IP used")
+			}
 			lastConnectTime = time.Now()
 
 			if _, err := s.StreamHeader(ctx, active, client); err != nil {
@@ -1949,7 +1952,10 @@ func (s *Service) handleBlockStream(ctx context.Context, client *common.ParentCl
 				Msg("stream block context cancelled")
 			return
 		default:
-			active := client.GetActiveClient(lastConnectTime)
+			active, safe := client.GetActiveClient(lastConnectTime)
+			if safe {
+				s.logger.Warn().Str("method", "streamBlock").Str("fastURL", client.FastClient.URL).Str("safeURL", client.SafeClient.URL).Msg("Fallback to safe IP used")
+			}
 			lastConnectTime = time.Now()
 			if _, err := s.StreamBlock(ctx, active); err != nil {
 				s.logger.Warn().
@@ -2426,7 +2432,10 @@ func (s *Service) handleBuilderInfoStream(ctx context.Context, client *common.Pa
 				Msg("stream block context cancelled")
 			return
 		default:
-			active := client.GetActiveClient(lastConnectTime)
+			active, safe := client.GetActiveClient(lastConnectTime)
+			if safe {
+				s.logger.Warn().Str("method", "streamBuilderInfo").Str("fastURL", client.FastClient.URL).Str("safeURL", client.SafeClient.URL).Msg("Fallback to safe IP used")
+			}
 			lastConnectTime = time.Now()
 
 			if _, err := s.StreamBuilderInfo(ctx, active); err != nil {
@@ -2907,7 +2916,10 @@ func (s *Service) handleSlotInfoStream(ctx context.Context, client *common.Paren
 				Msg("stream block context cancelled")
 			return
 		default:
-			active := client.GetActiveClient(lastConnectTime)
+			active, safe := client.GetActiveClient(lastConnectTime)
+			if safe {
+				s.logger.Warn().Str("method", "streamSlotInfo").Str("fastURL", client.FastClient.URL).Str("safeURL", client.SafeClient.URL).Msg("Fallback to safe IP used")
+			}
 			lastConnectTime = time.Now()
 
 			if _, err := s.StreamSlotInfo(ctx, active); err != nil {

--- a/service.go
+++ b/service.go
@@ -354,7 +354,9 @@ func (s *Service) handleStream(ctx context.Context, client *common.ParentClient)
 
 			active, safe := client.GetActiveClient(lastConnectTime)
 			if safe {
-				s.logger.Warn().Str("method", "streamHeader").Str("fastURL", client.FastClient.URL).Str("safeURL", client.SafeClient.URL).Msg("Fallback to safe IP used")
+				s.logger.Warn().Str("method", "streamHeader").Time("lastConnectTime", lastConnectTime).Str("fastURL", client.FastClient.URL).Str("safeURL", client.SafeClient.URL).Msg("Fallback to safe IP used")
+			} else {
+				s.logger.Info().Str("method", "streamHeader").Time("lastConnectTime", lastConnectTime).Str("fastURL", client.FastClient.URL).Str("safeURL", client.SafeClient.URL).Msg("fast IP used")
 			}
 			lastConnectTime = time.Now()
 

--- a/service_test.go
+++ b/service_test.go
@@ -95,10 +95,15 @@ func TestService_RegisterValidator(t *testing.T) {
 	}
 	for testName, tt := range tests {
 		t.Run(testName, func(t *testing.T) {
+			c := &common.Client{RelayClient: &mockRelayClient{RegisterValidatorFunc: tt.f}}
+			pc := &common.ParentClient{
+				SafeClient: c,
+				FastClient: c,
+			}
 			s := &Service{
 				logger:              zerolog.Nop(),
-				clients:             []*common.Client{{URL: "", NodeID: "", Conn: nil, RelayClient: &mockRelayClient{RegisterValidatorFunc: tt.f}}},
-				registrationClients: []*common.Client{{URL: "", NodeID: "", Conn: nil, RelayClient: &mockRelayClient{RegisterValidatorFunc: tt.f}}},
+				clients:             []*common.ParentClient{pc},
+				registrationClients: []*common.ParentClient{pc},
 				tracer:              noop.NewTracerProvider().Tracer("test"),
 				fluentD:             fluentstats.NewStats(true, "0.0.0.0:24224"),
 			}
@@ -178,7 +183,12 @@ func TestService_GetHeader(t *testing.T) {
 			opts := make([]ServiceOption, 0)
 			opts = append(opts, WithSvcLogger(zerolog.Nop()))
 			opts = append(opts, WithDataService(dSvc))
-			opts = append(opts, WithClients([]*common.Client{{URL: "", NodeID: "", Conn: nil, RelayClient: &mockRelayClient{}}}))
+			c := &common.Client{RelayClient: &mockRelayClient{}}
+			pc := &common.ParentClient{
+				SafeClient: c,
+				FastClient: c,
+			}
+			opts = append(opts, WithClients([]*common.ParentClient{pc}))
 			opts = append(opts, WithSvcTracer(noop.NewTracerProvider().Tracer("test")))
 			opts = append(opts, WithSvcFluentD(fluentstats.NewStats(true, "0.0.0.0:24224")))
 			opts = append(opts, WithSvcBeaconGenesisTime(1606824023))
@@ -236,7 +246,12 @@ func TestService_getPayload(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			var svcOpts []ServiceOption
 			svcOpts = append(svcOpts, WithSvcLogger(zerolog.Nop()))
-			svcOpts = append(svcOpts, WithClients([]*common.Client{{RelayClient: &mockRelayClient{GetPayloadFunc: tt.f}}}))
+			c := &common.Client{RelayClient: &mockRelayClient{GetPayloadFunc: tt.f}}
+			pc := &common.ParentClient{
+				SafeClient: c,
+				FastClient: c,
+			}
+			svcOpts = append(svcOpts, WithClients([]*common.ParentClient{pc}))
 			svcOpts = append(svcOpts, WithSvcTracer(noop.NewTracerProvider().Tracer("test")))
 			svcOpts = append(svcOpts, WithSvcFluentD(fluentstats.NewStats(true, "0.0.0.0:24224")))
 
@@ -513,15 +528,14 @@ func TestService_StreamHeaderAndGetMethod(t *testing.T) {
 		t.Fatal("Failed to create client connection", zap.Error(err))
 	}
 	defer conn.Close()
-	relayClient := relaygrpc.NewRelayClient(conn)
 	dSvc := NewDataService(WithDataSvcLogger(zerolog.Nop()))
 	svcOpts := make([]ServiceOption, 0)
-	c := &common.Client{URL: lis.Addr().String(), NodeID: "", Conn: conn, RelayClient: relayClient}
-	clients := []*common.Client{c}
-	sc := &common.Client{URL: lis.Addr().String(), NodeID: "", Conn: conn, RelayClient: relayClient}
-	streamingClients := []*common.Client{sc}
-	registrationClient := &common.Client{URL: lis.Addr().String(), NodeID: "", Conn: conn, RelayClient: relayClient}
-	registrationClients := []*common.Client{registrationClient}
+	c := common.NewParentClient(lis.Addr().String(), conn, lis.Addr().String(), conn)
+	clients := []*common.ParentClient{c}
+	sc := common.NewParentClient(lis.Addr().String(), conn, lis.Addr().String(), conn)
+	streamingClients := []*common.ParentClient{sc}
+	registrationClient := common.NewParentClient(lis.Addr().String(), conn, lis.Addr().String(), conn)
+	registrationClients := []*common.ParentClient{registrationClient}
 	tracer := noop.NewTracerProvider().Tracer("test")
 	svcOpts = append(svcOpts, WithSvcLogger(l))
 	svcOpts = append(svcOpts, WithClients(clients))
@@ -537,7 +551,7 @@ func TestService_StreamHeaderAndGetMethod(t *testing.T) {
 	service.accountsLists = &AccountsLists{AccountIDToInfo: make(map[string]*AccountInfo),
 		AccountNameToInfo: make(map[AccountName]*AccountInfo)}
 	go func() {
-		if _, err := service.StreamHeader(ctx, c); err != nil {
+		if _, err := service.StreamHeader(ctx, c.FastClient, c); err != nil {
 			panic(err)
 		}
 	}()
@@ -986,9 +1000,13 @@ func TestGetPayloadWithRetry(t *testing.T) {
 			mockClient.On("GetPayload", mock.Anything, mock.Anything).Return(tc.mockResp, tc.mockErr)
 			trcr := noop.NewTracerProvider().Tracer("")
 			_, span := trcr.Start(context.Background(), "")
-			client := &common.Client{URL: "", NodeID: "", Conn: nil, RelayClient: mockClient}
+			client := &common.Client{URL: "", NodeID: "", RelayClient: mockClient}
+			parentClient := &common.ParentClient{
+				SafeClient: client,
+				FastClient: client,
+			}
 			service := &Service{
-				clients: []*common.Client{client},
+				clients: []*common.ParentClient{parentClient},
 				tracer:  trcr,
 			}
 			result, err := service.getPayloadWithRetry(context.Background(), client, span, tc.mockReq, 2)


### PR DESCRIPTION
## 📝 Summary
Startup
```
{"level":"info","app":"RProxy","safeIP":"172.17.0.1:5015","fastIP":"XXXXXXX:5015","message":"Adding fast alternative IP"}
{"level":"info","app":"RProxy","parentClient":"ParentClient{FastClient: XXXXXXXX:5015, SafeClient: 172.17.0.1:5015}","message":"Added new Parent Client"}

```

Switchover to safe:
```
{"level":"info","app":"RProxy","method":"streamHeader","url":"XXXXXXX:5015","message":"streaming headers"}
{"level":"info","app":"RProxy","method":"streamHeader","url":"XXXXXXX:5015","message":"streaming headers"}
...
{"level":"warn","app":"RProxy","error":"rpc error: code = Unavailable desc = error reading from server: EOF","code":"Unavailable","method":"streamHeader","url":"XXXXXX:5015","message":"server unavailable, try reconnecting"}
{"level":"warn","app":"RProxy","method":"streamHeader","fastURL":"XXXXXXX:5015","safeURL":"172.17.0.1:5015","message":"Fallback to safe IP used"}
{"level":"info","app":"RProxy","method":"streamHeader","url":"172.17.0.1:5015","message":"streaming headers"}
```

Switchover back to fast:


## 💡 Motivation and Context

<!--- (Optional) Why is this change required? What problem does it solve? Remove this section if not applicable. -->

---

## ✅ I have completed the following steps:

* [ ] Run `make lint`
* [ ] Run `make test`
* [ ] Run `go mod tidy`
* [ ] Added tests (if applicable)
