### PR TITLE
MEV-1520/Relay-proxy-notify-when-slot-payload-has-been-delivered

### DIFF
--- a/server.go
+++ b/server.go
@@ -72,6 +72,7 @@ type Server struct {
 	NodeID         string
 	AdminAccountID string
 
+	// Callback
 	OnPayloadDelivered func(slot uint64, blockHash string, parentHash string, proposerPubkey string) error
 }
 
@@ -785,7 +786,7 @@ func (s *Server) HandleGetPayload(w http.ResponseWriter, r *http.Request) {
 			versionedPayloadInfo.GetParentHash(),
 			versionedPayloadInfo.GetPubkey(),
 		); err != nil {
-			log.Error().Err(err).Msg("Failed to broadcast payload delivered message to Redis subscribers")
+			log.Error().Err(err).Msg("Failed to call OnPayloadDelivered callback")
 		}
 	}(success)
 

--- a/server.go
+++ b/server.go
@@ -10,10 +10,11 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 
-	"github.com/bloXroute-Labs/relayproxy/common"
-	"github.com/bloXroute-Labs/relayproxy/fluentstats"
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/cors"
 	gjson "github.com/goccy/go-json"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
@@ -22,8 +23,8 @@ import (
 	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/grpc/metadata"
 
-	"github.com/go-chi/chi/v5"
-	"github.com/go-chi/cors"
+	"github.com/bloXroute-Labs/relayproxy/common"
+	"github.com/bloXroute-Labs/relayproxy/fluentstats"
 )
 
 // Router paths
@@ -70,6 +71,8 @@ type Server struct {
 	accountsLists  *AccountsLists
 	NodeID         string
 	AdminAccountID string
+
+	OnPayloadDelivered func(slot uint64, blockHash string, parentHash string, proposerPubkey string) error
 }
 
 type GetHeaderRateLimitInfo struct {
@@ -97,9 +100,11 @@ type account struct {
 
 func New(opts ...ServerOption) *Server {
 	server := new(Server)
+
 	for _, opt := range opts {
 		opt(server)
 	}
+
 	server.ghRatelimit = GetHeaderRateLimitInfo{
 		lastGetHeaderRequest: 0,
 		slotToIPToGHRequest:  NewIntegerMapOf[uint64, map[string]bool](),
@@ -143,6 +148,7 @@ func (s *Server) InitHandler() *chi.Mux {
 	s.logger.Info().Msg("Init relay proxy")
 	return handler
 }
+
 func addCORS() func(next http.Handler) http.Handler {
 	corsOpts := cors.Options{
 		AllowedOrigins: []string{"*"},
@@ -747,7 +753,7 @@ func (s *Server) HandleGetPayload(w http.ResponseWriter, r *http.Request) {
 		encodeJSONSpan.End()
 	}
 	span.AddEvent("handleGetPayload-svcGetPayload")
-	out, lm, err := s.svc.GetPayload(getPayloadCtx, &PayloadRequestParams{
+	versionedPayloadInfo, lm, err := s.svc.GetPayload(getPayloadCtx, &PayloadRequestParams{
 		ReceivedAt:                receivedAt,
 		Payload:                   bodyBytes,
 		ClientIP:                  clientIP,
@@ -765,13 +771,33 @@ func (s *Server) HandleGetPayload(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// If successful, execute the 'OnPayloadDelivered' callback after the function returns.
+	success := &atomic.Bool{}
+	success.Store(true)
+	defer func(success *atomic.Bool) {
+		if s.OnPayloadDelivered == nil || !success.Load() {
+			return
+		}
+
+		if err := s.OnPayloadDelivered(
+			versionedPayloadInfo.GetSlot(),
+			versionedPayloadInfo.GetBlockHash(),
+			versionedPayloadInfo.GetParentHash(),
+			versionedPayloadInfo.GetPubkey(),
+		); err != nil {
+			log.Error().Err(err).Msg("Failed to broadcast payload delivered message to Redis subscribers")
+		}
+	}(success)
+
+	// Return response
 	if !sszResponse {
-		respondOK(getPayloadCtx, getPayload, w, out, s.logger, s.tracer, logMetric)
+		respondOK(getPayloadCtx, getPayload, w, versionedPayloadInfo.GetResponse(), s.logger, s.tracer, logMetric)
 		return
 	}
 	payloadResponse := new(common.VersionedSubmitBlindedBlockResponse)
-	if err := payloadResponse.UnmarshalJSON(out.(json.RawMessage)); err != nil {
+	if err := payloadResponse.UnmarshalJSON(versionedPayloadInfo.GetResponse()); err != nil {
 		span.SetStatus(codes.Error, err.Error())
+		success.Store(false)
 		respondError(getPayloadCtx, getPayload, w, toErrorResp(http.StatusInternalServerError, err.Error(), logMetric.GetFields()), s.logger, s.tracer, logMetric)
 		return
 	}
@@ -779,7 +805,7 @@ func (s *Server) HandleGetPayload(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		log.Error().Err(err).Msg("failed to marshal getHeader to ssz")
 		span.SetStatus(codes.Error, err.Error())
-		respondOK(getPayloadCtx, getPayload, w, out, s.logger, s.tracer, logMetric)
+		respondOK(getPayloadCtx, getPayload, w, versionedPayloadInfo.GetResponse(), s.logger, s.tracer, logMetric)
 		return
 	}
 
@@ -879,7 +905,7 @@ func parseQuery(query string, value string, log zerolog.Logger, logMetric *LogMe
 	return proposerMevProtect, err
 }
 
-func (m *Server) respondOKWithContextSSZMarshalled(ctx context.Context, method string, w http.ResponseWriter, resBytes []byte, log zerolog.Logger, tracer trace.Tracer, logMetric *LogMetric) {
+func (s *Server) respondOKWithContextSSZMarshalled(ctx context.Context, method string, w http.ResponseWriter, resBytes []byte, log zerolog.Logger, tracer trace.Tracer, logMetric *LogMetric) {
 	_, span := tracer.Start(ctx, fmt.Sprintf("respondOKSSZ-%s", method))
 	defer span.End()
 	logMetric.Attributes(
@@ -891,11 +917,11 @@ func (m *Server) respondOKWithContextSSZMarshalled(ctx context.Context, method s
 
 	w.Header().Set(common.HeaderContentType, common.MediaTypeOctetStream)
 
-	_, writeHeaderSpan := m.tracer.Start(ctx, "writeHeader")
+	_, writeHeaderSpan := s.tracer.Start(ctx, "writeHeader")
 	w.WriteHeader(http.StatusOK)
 	writeHeaderSpan.End()
 
-	_, writeBytesSpan := m.tracer.Start(ctx, "writeBytes")
+	_, writeBytesSpan := s.tracer.Start(ctx, "writeBytes")
 	_, err := w.Write(resBytes)
 	writeBytesSpan.End()
 	if err != nil {

--- a/server.go
+++ b/server.go
@@ -641,7 +641,7 @@ func (s *Server) HandleGetHeader(w http.ResponseWriter, r *http.Request) {
 	}
 
 	versionedBid := new(common.VersionedSignedBuilderBid)
-	if err = versionedBid.UnmarshalJSON(out.(json.RawMessage)); err != nil {
+	if err = versionedBid.UnmarshalJSON(out); err != nil {
 		s.logger.Error().Err(err).Msg("Failed to unmarshal JSON")
 		respondError(handleGetHeaderCtx, getHeader, w, toErrorResp(http.StatusInternalServerError, err.Error(), lm.GetFields()), s.logger, s.tracer, logMetric)
 		return

--- a/server_test.go
+++ b/server_test.go
@@ -22,7 +22,7 @@ import (
 type MockService struct {
 	logger                    *zap.Logger
 	RegisterValidatorFunc     func(ctx context.Context, outgoingctx context.Context, in *RegistrationParams) (any, *LogMetric, error)
-	GetHeaderFunc             func(ctx context.Context, in *HeaderRequestParams) (any, *LogMetric, error)
+	GetHeaderFunc             func(ctx context.Context, in *HeaderRequestParams) (json.RawMessage, *LogMetric, error)
 	GetPayloadFunc            func(ctx context.Context, in *PayloadRequestParams) (*common.VersionedPayloadInfo, *LogMetric, error)
 	GetAccountsFunc           func(ctx context.Context) map[string]interface{}
 	SetAccountsFunc           func(ctx context.Context)
@@ -102,7 +102,7 @@ func (m *MockService) RegisterValidator(ctx context.Context, outgoingCtx context
 	}
 	return nil, new(LogMetric), nil
 }
-func (m *MockService) GetHeader(ctx context.Context, in *HeaderRequestParams) (any, *LogMetric, error) {
+func (m *MockService) GetHeader(ctx context.Context, in *HeaderRequestParams) (json.RawMessage, *LogMetric, error) {
 	if m.GetHeaderFunc != nil {
 		return m.GetHeaderFunc(ctx, in)
 	}
@@ -193,9 +193,9 @@ func TestServer_HandleGetHeader(t *testing.T) {
 			pubKey:     "pk123",
 			mockService: &MockService{
 				logger: zap.NewNop(),
-				GetHeaderFunc: func(ctx context.Context, in *HeaderRequestParams) (interface{}, *LogMetric, error) {
+				GetHeaderFunc: func(ctx context.Context, in *HeaderRequestParams) (json.RawMessage, *LogMetric, error) {
 
-					return "getHeader", nil, nil
+					return json.RawMessage("getHeader"), nil, nil
 				},
 			},
 			expectedCode:   http.StatusOK,
@@ -208,7 +208,7 @@ func TestServer_HandleGetHeader(t *testing.T) {
 			pubKey:     "pk456",
 			mockService: &MockService{
 				logger: zap.NewNop(),
-				GetHeaderFunc: func(ctx context.Context, in *HeaderRequestParams) (interface{}, *LogMetric, error) {
+				GetHeaderFunc: func(ctx context.Context, in *HeaderRequestParams) (json.RawMessage, *LogMetric, error) {
 					return nil, nil, &ErrorResp{Code: http.StatusNoContent}
 				},
 			},
@@ -222,7 +222,7 @@ func TestServer_HandleGetHeader(t *testing.T) {
 			pubKey:     "pk456",
 			mockService: &MockService{
 				logger: zap.NewNop(),
-				GetHeaderFunc: func(ctx context.Context, in *HeaderRequestParams) (interface{}, *LogMetric, error) {
+				GetHeaderFunc: func(ctx context.Context, in *HeaderRequestParams) (json.RawMessage, *LogMetric, error) {
 					return nil, nil, &ErrorResp{Code: http.StatusNoContent, Message: "header value is not present for the requested key slot"}
 				},
 			},
@@ -236,7 +236,7 @@ func TestServer_HandleGetHeader(t *testing.T) {
 			pubKey:     "pk456b",
 			mockService: &MockService{
 				logger: zap.NewNop(),
-				GetHeaderFunc: func(ctx context.Context, in *HeaderRequestParams) (interface{}, *LogMetric, error) {
+				GetHeaderFunc: func(ctx context.Context, in *HeaderRequestParams) (json.RawMessage, *LogMetric, error) {
 					return nil, nil, &ErrorResp{Code: http.StatusTooManyRequests, Message: "only one getheader request allowed per slot per validator"}
 				},
 			},

--- a/server_test.go
+++ b/server_test.go
@@ -10,19 +10,20 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/bloXroute-Labs/relayproxy/common"
 	"github.com/go-chi/chi/v5"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/otel/trace/noop"
 	"go.uber.org/zap"
+
+	"github.com/bloXroute-Labs/relayproxy/common"
 )
 
 type MockService struct {
 	logger                    *zap.Logger
 	RegisterValidatorFunc     func(ctx context.Context, outgoingctx context.Context, in *RegistrationParams) (any, *LogMetric, error)
 	GetHeaderFunc             func(ctx context.Context, in *HeaderRequestParams) (any, *LogMetric, error)
-	GetPayloadFunc            func(ctx context.Context, in *PayloadRequestParams) (any, *LogMetric, error)
+	GetPayloadFunc            func(ctx context.Context, in *PayloadRequestParams) (*common.VersionedPayloadInfo, *LogMetric, error)
 	GetAccountsFunc           func(ctx context.Context) map[string]interface{}
 	SetAccountsFunc           func(ctx context.Context)
 	SendAccountFunc           func(accountID, validatorID string)
@@ -89,7 +90,7 @@ func (m *MockService) DelayGetHeader(ctx context.Context, in DelayGetHeaderParam
 	}
 	return DelayGetHeaderResponse{}, nil
 }
-func (m *MockService) GetSlotDuty(slot uint64) (*common.MiniValidatorLatency, error) {
+func (m *MockService) GetSlotDuty(_ uint64) (*common.MiniValidatorLatency, error) {
 	return nil, nil
 }
 
@@ -108,7 +109,7 @@ func (m *MockService) GetHeader(ctx context.Context, in *HeaderRequestParams) (a
 	return nil, new(LogMetric), nil
 }
 
-func (m *MockService) GetPayload(ctx context.Context, in *PayloadRequestParams) (any, *LogMetric, error) {
+func (m *MockService) GetPayload(ctx context.Context, in *PayloadRequestParams) (*common.VersionedPayloadInfo, *LogMetric, error) {
 	if m.GetPayloadFunc != nil {
 		return m.GetPayloadFunc(ctx, in)
 	}
@@ -287,7 +288,7 @@ func TestServer_HandleGetPayload(t *testing.T) {
 			requestBody: []byte(`{"key": "value"}`),
 			mockService: &MockService{
 				logger: zap.NewNop(),
-				GetPayloadFunc: func(ctx context.Context, params *PayloadRequestParams) (any, *LogMetric, error) {
+				GetPayloadFunc: func(ctx context.Context, params *PayloadRequestParams) (*common.VersionedPayloadInfo, *LogMetric, error) {
 					return nil, nil, nil
 				},
 			},
@@ -298,7 +299,7 @@ func TestServer_HandleGetPayload(t *testing.T) {
 			requestBody: []byte(`{"key": "value"}`),
 			mockService: &MockService{
 				logger: zap.NewNop(),
-				GetPayloadFunc: func(ctx context.Context, params *PayloadRequestParams) (any, *LogMetric, error) {
+				GetPayloadFunc: func(ctx context.Context, params *PayloadRequestParams) (*common.VersionedPayloadInfo, *LogMetric, error) {
 					return nil, nil, toErrorResp(http.StatusInternalServerError, "failed to getPayload", nil)
 				},
 			},

--- a/service.go
+++ b/service.go
@@ -72,7 +72,7 @@ var (
 type IService interface {
 	IDataService
 	RegisterValidator(ctx context.Context, outgoingCtx context.Context, in *RegistrationParams) (any, *LogMetric, error)
-	GetHeader(ctx context.Context, in *HeaderRequestParams) (any, *LogMetric, error)
+	GetHeader(ctx context.Context, in *HeaderRequestParams) (json.RawMessage, *LogMetric, error)
 	GetPayload(ctx context.Context, in *PayloadRequestParams) (*common.VersionedPayloadInfo, *LogMetric, error)
 }
 type Service struct {
@@ -634,7 +634,7 @@ func (s *Service) StreamHeader(ctx context.Context, client *common.Client) (*rel
 	return nil, nil
 }
 
-func (s *Service) GetHeader(ctx context.Context, in *HeaderRequestParams) (any, *LogMetric, error) {
+func (s *Service) GetHeader(ctx context.Context, in *HeaderRequestParams) (json.RawMessage, *LogMetric, error) {
 	id := uuid.NewString()
 	parentSpan := trace.SpanFromContext(ctx)
 	ctx = trace.ContextWithSpan(context.Background(), parentSpan)

--- a/service.go
+++ b/service.go
@@ -19,11 +19,6 @@ import (
 
 	"github.com/attestantio/go-eth2-client/spec/bellatrix"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
-	relaygrpc "github.com/bloXroute-Labs/relay-grpc"
-	"github.com/bloXroute-Labs/relayproxy/common"
-	"github.com/bloXroute-Labs/relayproxy/fastjson"
-	"github.com/bloXroute-Labs/relayproxy/fluentstats"
-	"github.com/bloXroute-Labs/relayproxy/httpclient"
 	gethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/flashbots/go-boost-utils/bls"
 	"github.com/flashbots/go-boost-utils/ssz"
@@ -38,6 +33,12 @@ import (
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/timestamppb"
+
+	relaygrpc "github.com/bloXroute-Labs/relay-grpc"
+	"github.com/bloXroute-Labs/relayproxy/common"
+	"github.com/bloXroute-Labs/relayproxy/fastjson"
+	"github.com/bloXroute-Labs/relayproxy/fluentstats"
+	"github.com/bloXroute-Labs/relayproxy/httpclient"
 )
 
 const (
@@ -72,9 +73,12 @@ type IService interface {
 	IDataService
 	RegisterValidator(ctx context.Context, outgoingCtx context.Context, in *RegistrationParams) (any, *LogMetric, error)
 	GetHeader(ctx context.Context, in *HeaderRequestParams) (any, *LogMetric, error)
-	GetPayload(ctx context.Context, in *PayloadRequestParams) (any, *LogMetric, error)
+	GetPayload(ctx context.Context, in *PayloadRequestParams) (*common.VersionedPayloadInfo, *LogMetric, error)
 }
 type Service struct {
+	// data service
+	IDataService
+
 	logger      zerolog.Logger
 	version     string // build version
 	nodeID      string // UUID
@@ -117,8 +121,6 @@ type Service struct {
 	accountsLists       *AccountsLists
 	walletAccounts      *map[string]*common.WalletAccount
 	miniProposerSlotMap *SyncMap[uint64, *common.MiniValidatorLatency]
-	// data service
-	IDataService
 }
 
 type slotStatsEvent struct {
@@ -1377,7 +1379,7 @@ func (s *Service) validateAndFetchPayload(ctx context.Context, logMetric *LogMet
 	}, toErrorResp(http.StatusOK, "pre fetch payload not available in cache", logMetric.GetFields())
 }
 
-func (s *Service) GetPayload(ctx context.Context, in *PayloadRequestParams) (any, *LogMetric, error) {
+func (s *Service) GetPayload(ctx context.Context, in *PayloadRequestParams) (*common.VersionedPayloadInfo, *LogMetric, error) {
 	startTime := time.Now().UTC()
 	id := uuid.NewString()
 	parentSpan := trace.SpanFromContext(ctx)
@@ -1537,7 +1539,7 @@ func (s *Service) GetPayload(ctx context.Context, in *PayloadRequestParams) (any
 				attribute.String("blockValue", resp.BlockValue),
 				attribute.String("uniqueKey", uKey),
 			)
-			return json.RawMessage(resp.Response), logMetric, nil
+			return resp, logMetric, nil
 		case errResp = <-errChan:
 			// if multiple client return errors, first error gets replaced by the subsequent errors
 		}

--- a/service_test.go
+++ b/service_test.go
@@ -18,9 +18,6 @@ import (
 	"time"
 
 	"github.com/attestantio/go-builder-client/spec"
-	relaygrpc "github.com/bloXroute-Labs/relay-grpc"
-	"github.com/bloXroute-Labs/relayproxy/common"
-	"github.com/bloXroute-Labs/relayproxy/fluentstats"
 	"github.com/patrickmn/go-cache"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
@@ -31,6 +28,10 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
+
+	relaygrpc "github.com/bloXroute-Labs/relay-grpc"
+	"github.com/bloXroute-Labs/relayproxy/common"
+	"github.com/bloXroute-Labs/relayproxy/fluentstats"
 )
 
 const (
@@ -61,7 +62,6 @@ const (
 )
 
 func TestService_RegisterValidator(t *testing.T) {
-
 	tests := map[string]struct {
 		f           func(ctx context.Context, req *relaygrpc.RegisterValidatorRequest, opts ...grpc.CallOption) (*relaygrpc.RegisterValidatorResponse, error)
 		wantSuccess any
@@ -93,6 +93,7 @@ func TestService_RegisterValidator(t *testing.T) {
 			wantErr: toErrorResp(http.StatusInternalServerError, "relay returned failure response code", map[string]any{}),
 		},
 	}
+
 	for testName, tt := range tests {
 		t.Run(testName, func(t *testing.T) {
 			s := &Service{
@@ -113,7 +114,6 @@ func TestService_RegisterValidator(t *testing.T) {
 }
 
 func TestService_GetHeader(t *testing.T) {
-
 	tests := map[string]struct {
 		slot               string
 		parentHash         string
@@ -206,7 +206,6 @@ func TestService_GetHeader(t *testing.T) {
 }
 
 func TestService_getPayload(t *testing.T) {
-
 	tests := map[string]struct {
 		f           func(ctx context.Context, req *relaygrpc.GetPayloadRequest, opts ...grpc.CallOption) (*relaygrpc.GetPayloadResponse, error)
 		wantSuccess []byte
@@ -245,13 +244,14 @@ func TestService_getPayload(t *testing.T) {
 				AccountNameToInfo: make(map[AccountName]*AccountInfo)}
 			got, _, err := s.GetPayload(context.Background(), &PayloadRequestParams{AuthHeader: TestAuthHeader})
 			if err == nil {
-				assert.Equal(t, string(got.(json.RawMessage)), string(tt.wantSuccess))
+				assert.Equal(t, string(got.GetResponse()), string(tt.wantSuccess))
 				return
 			}
 			assert.Equal(t, err.Error(), tt.wantErr.Error())
 		})
 	}
 }
+
 func TestBlockCancellation(t *testing.T) {
 	s := &Service{
 		logger:                  zerolog.Nop(),


### PR DESCRIPTION
## 📝 Summary

This PR adds an optional `OnPayloadDelivered` callback and calls it when a `GetPayload` response is delivered.

Also adds a concrete type to the `GetHeader` and `GetPayload` interface function return values.

## 💡 Motivation and Context

<!--- (Optional) Why is this change required? What problem does it solve? Remove this section if not applicable. -->

---

## ✅ I have completed the following steps:

* [ ] Run `make lint`
* [ ] Run `make test`
* [ ] Run `go mod tidy`
* [ ] Added tests (if applicable)
