### PR TITLE
Better getPayload Spans

### DIFF
--- a/service.go
+++ b/service.go
@@ -938,7 +938,7 @@ func (s *Service) PreFetchGetPayload(ctx context.Context, fields preFetcherField
 	ctx = trace.ContextWithSpan(context.Background(), parentSpan)
 	ctx = metadata.AppendToOutgoingContext(ctx, "authorization", s.authKey)
 	_, span := s.tracer.Start(ctx, "preFetchGetPayload-start")
-	defer span.End(trace.WithTimestamp(time.Now()))
+	defer span.End()
 
 	if fields.client != nil {
 		clientURL = fields.client.SafeClient.URL
@@ -1410,7 +1410,8 @@ func (s *Service) GetPayload(ctx context.Context, in *PayloadRequestParams) (*co
 	}
 	ctx = metadata.AppendToOutgoingContext(ctx, "authorization", s.authKey)
 	ctx, span := s.tracer.Start(ctx, "getPayload-start")
-	defer span.End(trace.WithTimestamp(time.Now()))
+	defer span.End()
+	_, timeToRelayRequestSpan := s.tracer.Start(ctx, "getPayload-TimeToRelayRequest")
 	var (
 		latency int64
 	)
@@ -1422,6 +1423,7 @@ func (s *Service) GetPayload(ctx context.Context, in *PayloadRequestParams) (*co
 			latency = in.ReceivedAt.Sub(time.UnixMilli(getPayloadStartTime)).Milliseconds()
 		}
 	}
+	_, logTimingSpan := s.tracer.Start(ctx, "getPayload-logTimingSpan")
 
 	logMetric := NewLogMetric(
 		map[string]any{
@@ -1462,6 +1464,7 @@ func (s *Service) GetPayload(ctx context.Context, in *PayloadRequestParams) (*co
 	respChan := make(chan *common.VersionedPayloadInfo, len(s.clients)+prefetchAttempts)
 	attempts := make([]struct{}, prefetchAttempts)
 	metricCopy := logMetric.Copy()
+	logTimingSpan.End()
 	var wg sync.WaitGroup
 	wg.Add(1)
 	totalPrefetchResponses := 1
@@ -1502,7 +1505,7 @@ func (s *Service) GetPayload(ctx context.Context, in *PayloadRequestParams) (*co
 		ReceivedAt:  timestamppb.New(in.ReceivedAt),
 		SecretToken: s.secretToken,
 	}
-
+	timeToRelayRequestSpan.End()
 	ctx, payloadResponseSpan := s.tracer.Start(ctx, "getPayload-payloadResponseFromRelay")
 	for _, client := range s.clients {
 		wg.Add(1)

--- a/service.go
+++ b/service.go
@@ -1535,6 +1535,7 @@ func (s *Service) GetPayload(ctx context.Context, in *PayloadRequestParams) (*co
 			go s.sendPayloadStats(in.Payload, logMetricCopy, false, nil, in.ReceivedAt, startTime, time.Now(), 0, id, in.ClientIP, in.ValidatorID, in.AccountID, latency, in.Cluster, in.UserAgent, in.SlotUID)
 			logMetric.Error(ctx.Err())
 			logMetric.String("relayError", "failed to getPayload")
+			payloadResponseSpan.End()
 			return nil, logMetric, toErrorResp(http.StatusInternalServerError, ctx.Err().Error(), map[string]any{"relayError": "failed to getPayload"})
 		case resp := <-respChan:
 			logMetricCopy := logMetric.Copy()
@@ -1563,6 +1564,7 @@ func (s *Service) GetPayload(ctx context.Context, in *PayloadRequestParams) (*co
 				attribute.String("blockValue", resp.BlockValue),
 				attribute.String("uniqueKey", uKey),
 			)
+			payloadResponseSpan.End()
 			return resp, logMetric, nil
 		case errResp = <-errChan:
 			// if multiple client return errors, first error gets replaced by the subsequent errors


### PR DESCRIPTION
## 📝 Summary

This is how the current span looks like: Notice that theres a huge gap (red line) and the parent span time doesn't cover the child spans 
![image](https://github.com/user-attachments/assets/a7afb0d7-7658-429a-90d1-6ca94ae61330)
- the parent span should cover the entire period
- adds a couple of child spans to see whats taking so long


## 💡 Motivation and Context

<!--- (Optional) Why is this change required? What problem does it solve? Remove this section if not applicable. -->

---

## ✅ I have completed the following steps:

* [ ] Run `make lint`
* [ ] Run `make test`
* [ ] Run `go mod tidy`
* [ ] Added tests (if applicable)
