### PR TITLE
init live el reward calculation

### DIFF
--- a/cmd/relayproxy/main.go
+++ b/cmd/relayproxy/main.go
@@ -305,7 +305,7 @@ func main() {
 	}
 	rewardEngineCh := make(chan relayproxy.SlotStatsRecord, 100) // channel to receive slot starts record for reward calculation
 	var externalRelayUrlsWithApiKeys map[string]string
-	if err = json.Unmarshal([]byte(*externalRelayURLWithAPIKeyJSON), externalRelayUrlsWithApiKeys); err != nil {
+	if err = json.Unmarshal([]byte(*externalRelayURLWithAPIKeyJSON), &externalRelayUrlsWithApiKeys); err != nil {
 		l.Fatal().Err(err).Msg("failed to unmarshal external relays with api keys json object")
 	}
 	l.Info().

--- a/cmd/relayproxy/main.go
+++ b/cmd/relayproxy/main.go
@@ -304,7 +304,7 @@ func main() {
 		l.Fatal().Err(err).Msg("failed to compute builder signing domain")
 	}
 	rewardEngineCh := make(chan relayproxy.SlotStatsRecord, 100) // channel to receive slot starts record for reward calculation
-	var externalRelayUrlsWithApiKeys map[string]string
+	externalRelayUrlsWithApiKeys := make(map[string]string)
 	if err = json.Unmarshal([]byte(*externalRelayURLWithAPIKeyJSON), &externalRelayUrlsWithApiKeys); err != nil {
 		l.Fatal().Err(err).Msg("failed to unmarshal external relays with api keys json object")
 	}

--- a/cmd/relayproxy/main.go
+++ b/cmd/relayproxy/main.go
@@ -85,7 +85,12 @@ var (
 	skipAuth         = flag.Bool("skip-auth", false, "auth header authentication skip flag")
 
 	// external relay
-	externalRelayURL = flag.String("external-relay", "", "external relay to be called")
+	externalRelayURL               = flag.String("external-relay", "", "external relay to be called")
+	externalRelayURLWithAPIKeyJSON = flag.String(
+		"external-relay-urls-api-key-json",
+		"{}",
+		"JSON string mapping external relay URLs to their corresponding API keys. Example: '{\"https://bloxroute.max-profit.blxrbdn.com\": \"xxxxxxx\"}'",
+	)
 )
 var (
 	grpcPort          = flag.String("grpc-port", "5001", "grpc port")
@@ -298,7 +303,11 @@ func main() {
 	if err != nil {
 		l.Fatal().Err(err).Msg("failed to compute builder signing domain")
 	}
-
+	rewardEngineCh := make(chan relayproxy.SlotStatsRecord, 100) // channel to review slot starts record for reward calculation
+	var externalRelayUrlsWithApiKeys map[string]string
+	if err = json.Unmarshal([]byte(*externalRelayURLWithAPIKeyJSON), externalRelayUrlsWithApiKeys); err != nil {
+		l.Fatal().Err(err).Msg("failed to unmarshal external relays with api keys json object")
+	}
 	l.Info().
 		Str("listenAddr", *listenAddr).
 		Str("uptraceDSN", *uptraceDSN).
@@ -319,10 +328,19 @@ func main() {
 		Msg("Starting relay proxy server")
 
 	var (
-		dataSvcOpts []relayproxy.DataServiceOption
-		svcOpts     []relayproxy.ServiceOption
-		serverOpts  []relayproxy.ServerOption
+		rewardEngineOpts []relayproxy.RewardEngineOpts
+		dataSvcOpts      []relayproxy.DataServiceOption
+		svcOpts          []relayproxy.ServiceOption
+		serverOpts       []relayproxy.ServerOption
 	)
+	rewardEngineOpts = append(rewardEngineOpts, relayproxy.WithRewardEngineLogger(l))
+	rewardEngineOpts = append(rewardEngineOpts, relayproxy.WithRewardEngineHttpClient(httpClient))
+	rewardEngineOpts = append(rewardEngineOpts, relayproxy.WithRewardEngineSlotStatsRecordCh(rewardEngineCh))
+	rewardEngineOpts = append(rewardEngineOpts, relayproxy.WithRewardEngineRelayUrlsWithApiKey(externalRelayUrlsWithApiKeys))
+	rewardEngineOpts = append(rewardEngineOpts, relayproxy.WithRewardEngineNodeID(*nodeID))
+	rewardEngineOpts = append(rewardEngineOpts, relayproxy.WithRewardEngineFluentd(fluentLogger))
+	rewardEngine := relayproxy.NewElRewardEngine(rewardEngineOpts...)
+
 	dataSvcOpts = append(dataSvcOpts, relayproxy.WithDataSvcLogger(l))
 	dataSvcOpts = append(dataSvcOpts, relayproxy.WithDataSvcNodeID(*nodeID))
 	dataSvcOpts = append(dataSvcOpts, relayproxy.WithDataSvcTracer(tracer))
@@ -369,6 +387,7 @@ func main() {
 	svcOpts = append(svcOpts, relayproxy.WithSvcListenAddress(*listenAddr))
 	svcOpts = append(svcOpts, relayproxy.WithSvcGrpcListenAddress(*grpcPort))
 	svcOpts = append(svcOpts, relayproxy.WithAccountList(accountsLists))
+	svcOpts = append(svcOpts, relayproxy.WithSlotStatsRecordCh(rewardEngineCh))
 
 	svc := relayproxy.NewService(svcOpts...)
 

--- a/cmd/relayproxy/main.go
+++ b/cmd/relayproxy/main.go
@@ -419,6 +419,8 @@ func main() {
 		server.Stop()
 		close(exit)
 	}()
+	// start el reward engine
+	go rewardEngine.Start(ctx)
 
 	// start receiving account info
 	go dataSvc.SetAccounts(ctx)

--- a/cmd/relayproxy/main.go
+++ b/cmd/relayproxy/main.go
@@ -303,7 +303,7 @@ func main() {
 	if err != nil {
 		l.Fatal().Err(err).Msg("failed to compute builder signing domain")
 	}
-	rewardEngineCh := make(chan relayproxy.SlotStatsRecord, 100) // channel to review slot starts record for reward calculation
+	rewardEngineCh := make(chan relayproxy.SlotStatsRecord, 100) // channel to receive slot starts record for reward calculation
 	var externalRelayUrlsWithApiKeys map[string]string
 	if err = json.Unmarshal([]byte(*externalRelayURLWithAPIKeyJSON), externalRelayUrlsWithApiKeys); err != nil {
 		l.Fatal().Err(err).Msg("failed to unmarshal external relays with api keys json object")

--- a/el_reward_engine.go
+++ b/el_reward_engine.go
@@ -40,6 +40,7 @@ type BidTrace struct {
 	ValueEth                string `json:"value_eth"`
 	ProposerSendTimestampMs string `json:"proposer_send_timestamp_ms"`
 	ExtraData               string `json:"extra_data"`
+	RelayURL                string `json:"-"`
 }
 
 type ElRewardInfo struct {
@@ -86,8 +87,8 @@ func (r *RewardEngine) Start(ctx context.Context) {
 	}
 }
 
-func (r *RewardEngine) collectExternalRelayBids(slot uint64) []BidTrace {
-	var allBids []BidTrace
+func (r *RewardEngine) collectExternalRelayBids(slot uint64) map[string][]BidTrace {
+	relayBids := make(map[string][]BidTrace)
 
 	for baseURL, apiKey := range r.relayUrlsWithApiKeys {
 		url := fmt.Sprintf("%s%s%d", baseURL, proposerHeaderDeliveredURI, slot)
@@ -105,19 +106,28 @@ func (r *RewardEngine) collectExternalRelayBids(slot uint64) []BidTrace {
 
 		body, err := io.ReadAll(resp.Body)
 		resp.Body.Close()
+		if err != nil {
+			r.logger.Error().Err(err).Msg("failed to read body from relay")
+			continue
+		}
+
 		var bids []BidTrace
 		if err = json.Unmarshal(body, &bids); err != nil {
 			r.logger.Error().Err(err).Msg("failed to unmarshal bid trace")
 			continue
 		}
-		allBids = append(allBids, bids...)
+		for i := range bids {
+			bids[i].RelayURL = baseURL
+		}
+
+		relayBids[baseURL] = bids
 	}
 
-	return allBids
+	return relayBids
 }
 
 // TODO: Recovery option, move as a standalone script to calculate based on db and endpoints
-func (r *RewardEngine) calculateElRewardInfo(slotStats SlotStatsRecord, allBids []BidTrace) ElRewardInfo {
+func (r *RewardEngine) calculateElRewardInfo(slotStats SlotStatsRecord, groupedBids map[string][]BidTrace) ElRewardInfo {
 	elInfo := ElRewardInfo{
 		Slot:                          fmt.Sprintf("%d", slotStats.Slot),
 		SlotUID:                       slotStats.HeaderSlotUID,
@@ -130,10 +140,12 @@ func (r *RewardEngine) calculateElRewardInfo(slotStats SlotStatsRecord, allBids 
 	}
 
 	var matchedBids []BidTrace
-	for _, bid := range allBids {
-		elInfo.Bids[bid.ProposerSendTimestampMs] = append(elInfo.Bids[bid.ProposerSendTimestampMs], bid)
-		if bid.ProposerSendTimestampMs == slotStats.HeaderStartTimeUnixMs {
-			matchedBids = append(matchedBids, bid)
+	for relayURL, bids := range groupedBids {
+		elInfo.Bids[relayURL] = bids
+		for _, bid := range bids {
+			if bid.ProposerSendTimestampMs == slotStats.HeaderStartTimeUnixMs {
+				matchedBids = append(matchedBids, bid)
+			}
 		}
 	}
 
@@ -141,6 +153,7 @@ func (r *RewardEngine) calculateElRewardInfo(slotStats SlotStatsRecord, allBids 
 		return elInfo
 	}
 
+	// Sort by value (ascending)
 	sort.SliceStable(matchedBids, func(i, j int) bool {
 		iVal, _ := new(big.Float).SetString(matchedBids[i].ValueEth)
 		jVal, _ := new(big.Float).SetString(matchedBids[j].ValueEth)
@@ -155,11 +168,12 @@ func (r *RewardEngine) calculateElRewardInfo(slotStats SlotStatsRecord, allBids 
 	percentPrecise := new(big.Float).Quo(increase, winVal)
 	percentPrecise.Mul(percentPrecise, big.NewFloat(100))
 
-	// Check equality: if second best bid == winning bid
+	// Check if second best bid == winning bid
 	isEqual := winVal.Cmp(secondVal) == 0
 	elInfo.IsEqualToProxyBid = isEqual
 	if isEqual {
 		elInfo.IsProxyWin = false
+		elInfo.EqualToProxyBidders = secondHighest.RelayURL
 	}
 
 	onchainFloat, _ := winVal.Float64()
@@ -178,30 +192,31 @@ func (r *RewardEngine) calculateElRewardInfo(slotStats SlotStatsRecord, allBids 
 	elRewardWei.Int(elInfo.ElRewardIncreaseWei)
 
 	//TODO: Perform fee per block calculation only certain accountID
-	if elInfo.ElRewardIncreasePercentage <= 1 {
+	switch {
+	case elInfo.ElRewardIncreasePercentage <= 1:
 		elInfo.FeePerBlock = 0.0
-	} else if elInfo.ElRewardIncreasePercentage <= 5 {
+	case elInfo.ElRewardIncreasePercentage <= 5:
 		if elInfo.ElRewardIncreaseEth >= 0.0015 {
 			elInfo.FeePerBlock = 0.0015
-		} else {
-			elInfo.FeePerBlock = 0.0
 		}
-	} else if elInfo.ElRewardIncreasePercentage <= 9 {
-		if elInfo.ElRewardIncreaseEth > 0.003 {
+	case elInfo.ElRewardIncreasePercentage <= 9:
+		switch {
+		case elInfo.ElRewardIncreaseEth > 0.003:
 			elInfo.FeePerBlock = 0.003
-		} else if elInfo.ElRewardIncreaseEth > 0.0015 {
+		case elInfo.ElRewardIncreaseEth > 0.0015:
 			elInfo.FeePerBlock = 0.0015
-		} else {
+		default:
 			elInfo.FeePerBlock = 0.0
 		}
-	} else {
-		if elInfo.ElRewardIncreaseEth > 0.005 {
+	default:
+		switch {
+		case elInfo.ElRewardIncreaseEth > 0.005:
 			elInfo.FeePerBlock = 0.005
-		} else if elInfo.ElRewardIncreaseEth > 0.003 {
+		case elInfo.ElRewardIncreaseEth > 0.003:
 			elInfo.FeePerBlock = 0.003
-		} else if elInfo.ElRewardIncreaseEth > 0.0015 {
+		case elInfo.ElRewardIncreaseEth > 0.0015:
 			elInfo.FeePerBlock = 0.0015
-		} else {
+		default:
 			elInfo.FeePerBlock = 0.0
 		}
 	}

--- a/el_reward_engine.go
+++ b/el_reward_engine.go
@@ -1,0 +1,221 @@
+package relayproxy
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math/big"
+	"net/http"
+	"sort"
+	"time"
+
+	"github.com/bloXroute-Labs/relayproxy/fluentstats"
+	"github.com/rs/zerolog"
+)
+
+const (
+	proposerHeaderDeliveredURI = "/relay/v1/data/bidtraces/proposer_header_delivered?slot="
+)
+
+type RewardEngine struct {
+	logger               zerolog.Logger
+	httpClient           *http.Client
+	slotStartRecordCh    chan SlotStatsRecord
+	relayUrlsWithApiKeys map[string]string
+	nodeID               string
+	fluentd              fluentstats.Stats
+}
+
+type BidTrace struct {
+	HeaderRequestID         string `json:"header_request_id"`
+	Slot                    string `json:"slot"`
+	ParentHash              string `json:"parent_hash"`
+	BlockHash               string `json:"block_hash"`
+	BuilderPubkey           string `json:"builder_pubkey"`
+	ProposerPubkey          string `json:"proposer_pubkey"`
+	ProposerFeeRecipient    string `json:"proposer_fee_recipient"`
+	Value                   string `json:"value"`
+	BlockNumber             string `json:"block_number"`
+	ValueEth                string `json:"value_eth"`
+	ProposerSendTimestampMs string `json:"proposer_send_timestamp_ms"`
+	ExtraData               string `json:"extra_data"`
+}
+
+type ElRewardInfo struct {
+	Slot                           string                `json:"slot"`
+	SlotUID                        string                `json:"slot_uid"`
+	BlockNumber                    string                `json:"block_number"`
+	Bids                           map[string][]BidTrace `json:"bids"`
+	SelectedHeaderStartTimeUnixMs  string                `json:"selected_header_start_time_unix_ms"`
+	BlockHash                      string                `json:"block_hash"`
+	IsProxyWin                     bool                  `json:"is_proxy_win"`
+	IsWinningBidHighest            bool                  `json:"is_winning_bid_highest"`
+	ElRewardIncreaseWei            *big.Int              `json:"el_reward_increase_wei"`
+	ElRewardIncreaseEth            float64               `json:"el_reward_increase_eth"`
+	OnchainBidValue                float64               `json:"onchain_bid_value"`
+	SecondHighestBidValue          float64               `json:"second_highest_bid_value"`
+	OnchainBidDeliveredRelay       string                `json:"onchain_bid_delivered_relay"`
+	SecondHigherBidDeliveredRelay  string                `json:"second_higher_bid_delivered_relay"`
+	IsPayloadReceived              bool                  `json:"is_payload_received"`
+	ElRewardIncreasePercentage     uint64                `json:"el_reward_increase_percentage"`
+	ElRewardIncreasePercentPrecise float64               `json:"el_reward_increase_percent_precise"`
+	EqualToProxyBidders            string                `json:"equal_to_proxy_bidders"`
+	IsEqualToProxyBid              bool                  `json:"is_equal_to_proxy_bid"`
+	FeePerBlock                    float64               `json:"fee_per_block"`
+}
+
+func NewElRewardEngine(opts ...RewardEngineOpts) *RewardEngine {
+	rewardEngine := &RewardEngine{}
+	for _, opt := range opts {
+		opt(rewardEngine)
+	}
+	return rewardEngine
+}
+
+func (r *RewardEngine) Start(ctx context.Context) {
+	for {
+		select {
+		case slotStats := <-r.slotStartRecordCh:
+			bids := r.collectExternalRelayBids(slotStats.Slot)
+			reward := r.calculateElRewardInfo(slotStats, bids)
+			r.logger.Info().Msgf("calculated EL reward: %v", reward) //TODO:omit bids while logging to avoid cluttering
+		default:
+		}
+	}
+}
+
+func (r *RewardEngine) collectExternalRelayBids(slot uint64) []BidTrace {
+	var allBids []BidTrace
+
+	for baseURL, apiKey := range r.relayUrlsWithApiKeys {
+		url := fmt.Sprintf("%s%s%d", baseURL, proposerHeaderDeliveredURI, slot)
+		req, err := http.NewRequest(http.MethodGet, url, nil)
+		if err != nil {
+			r.logger.Error().Err(err).Str("url", baseURL).Msg("failed to create proposer header delivered request")
+			continue
+		}
+		req.Header.Set("X-API-Key", apiKey)
+		resp, err := r.httpClient.Do(req)
+		if err != nil || resp.StatusCode != http.StatusOK {
+			r.logger.Error().Err(err).Msgf("http request failed or returned non-200 from %s", baseURL)
+			continue
+		}
+
+		body, err := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		var bids []BidTrace
+		if err = json.Unmarshal(body, &bids); err != nil {
+			r.logger.Error().Err(err).Msg("failed to unmarshal bid trace")
+			continue
+		}
+		allBids = append(allBids, bids...)
+	}
+
+	return allBids
+}
+
+// TODO: Recovery option, move as a standalone script to calculate based on db and endpoints
+func (r *RewardEngine) calculateElRewardInfo(slotStats SlotStatsRecord, allBids []BidTrace) ElRewardInfo {
+	elInfo := ElRewardInfo{
+		Slot:                          fmt.Sprintf("%d", slotStats.Slot),
+		SlotUID:                       slotStats.HeaderSlotUID,
+		BlockHash:                     slotStats.PayloadDeliveredBlockHash,
+		SelectedHeaderStartTimeUnixMs: slotStats.HeaderStartTimeUnixMs,
+		IsPayloadReceived:             slotStats.PayloadSucceeded,
+		IsProxyWin:                    slotStats.HeaderDeliveredBlockHash == slotStats.PayloadDeliveredBlockHash,
+		Bids:                          make(map[string][]BidTrace),
+		ElRewardIncreaseWei:           big.NewInt(0),
+	}
+
+	var matchedBids []BidTrace
+	for _, bid := range allBids {
+		elInfo.Bids[bid.ProposerSendTimestampMs] = append(elInfo.Bids[bid.ProposerSendTimestampMs], bid)
+		if bid.ProposerSendTimestampMs == slotStats.HeaderStartTimeUnixMs {
+			matchedBids = append(matchedBids, bid)
+		}
+	}
+
+	if len(matchedBids) < 2 {
+		return elInfo
+	}
+
+	sort.SliceStable(matchedBids, func(i, j int) bool {
+		iVal, _ := new(big.Float).SetString(matchedBids[i].ValueEth)
+		jVal, _ := new(big.Float).SetString(matchedBids[j].ValueEth)
+		return iVal.Cmp(jVal) < 0
+	})
+
+	secondHighest := matchedBids[len(matchedBids)-1]
+
+	winVal, _ := new(big.Float).SetString(slotStats.PayloadBlockValue)
+	secondVal, _ := new(big.Float).SetString(secondHighest.ValueEth)
+	increase := new(big.Float).Sub(winVal, secondVal)
+	percentPrecise := new(big.Float).Quo(increase, winVal)
+	percentPrecise.Mul(percentPrecise, big.NewFloat(100))
+
+	// Check equality: if second best bid == winning bid
+	isEqual := winVal.Cmp(secondVal) == 0
+	elInfo.IsEqualToProxyBid = isEqual
+	if isEqual {
+		elInfo.IsProxyWin = false
+	}
+
+	onchainFloat, _ := winVal.Float64()
+	secondFloat, _ := secondVal.Float64()
+	incFloat, _ := increase.Float64()
+	percentFloat, _ := percentPrecise.Float64()
+
+	elInfo.OnchainBidValue = onchainFloat
+	elInfo.SecondHighestBidValue = secondFloat
+	elInfo.ElRewardIncreaseEth = incFloat
+	elInfo.ElRewardIncreasePercentPrecise = percentFloat
+	elInfo.ElRewardIncreasePercentage = uint64(percentFloat + 0.5)
+
+	weiFactor := new(big.Float).SetFloat64(1e18)
+	elRewardWei := new(big.Float).Mul(increase, weiFactor)
+	elRewardWei.Int(elInfo.ElRewardIncreaseWei)
+
+	//TODO: Perform fee per block calculation only certain accountID
+	if elInfo.ElRewardIncreasePercentage <= 1 {
+		elInfo.FeePerBlock = 0.0
+	} else if elInfo.ElRewardIncreasePercentage <= 5 {
+		if elInfo.ElRewardIncreaseEth >= 0.0015 {
+			elInfo.FeePerBlock = 0.0015
+		} else {
+			elInfo.FeePerBlock = 0.0
+		}
+	} else if elInfo.ElRewardIncreasePercentage <= 9 {
+		if elInfo.ElRewardIncreaseEth > 0.003 {
+			elInfo.FeePerBlock = 0.003
+		} else if elInfo.ElRewardIncreaseEth > 0.0015 {
+			elInfo.FeePerBlock = 0.0015
+		} else {
+			elInfo.FeePerBlock = 0.0
+		}
+	} else {
+		if elInfo.ElRewardIncreaseEth > 0.005 {
+			elInfo.FeePerBlock = 0.005
+		} else if elInfo.ElRewardIncreaseEth > 0.003 {
+			elInfo.FeePerBlock = 0.003
+		} else if elInfo.ElRewardIncreaseEth > 0.0015 {
+			elInfo.FeePerBlock = 0.0015
+		} else {
+			elInfo.FeePerBlock = 0.0
+		}
+	}
+	return elInfo
+}
+
+func (r *RewardEngine) logRecord(record ElRewardInfo) {
+	r.logger.Info().
+		Str("slotKey", record.Slot).
+		Str("blockHah", record.BlockHash).
+		Float64("blockHah", record.ElRewardIncreaseEth).
+		Bool("isProxyWin", record.IsProxyWin).
+		Msg("emit el reward event")
+	r.fluentd.LogToFluentD(fluentstats.Record{
+		Type: TypeRelayProxySlotStats,
+		Data: record,
+	}, time.Now().UTC(), r.nodeID, StatsRelayProxyElReward)
+}

--- a/el_reward_engine.go
+++ b/el_reward_engine.go
@@ -193,7 +193,7 @@ func (r *RewardEngine) calculateElRewardInfo(slotStats SlotStatsRecord, groupedB
 		winVal, ok := new(big.Float).SetString(slotStats.PayloadBlockValue)
 		if !ok {
 			errBuf = append(errBuf, "invalid payloadBlockValue")
-			r.logger.Warn().Uint64("slot", slotStats.Slot).Str("blockValue", slotStats.PayloadBlockValue).Msg("invalid payloadBlockValue")
+			r.logger.Warn().Bool("is_proxy_win", elInfo.IsProxyWin).Uint64("slot", slotStats.Slot).Str("blockValue", slotStats.PayloadBlockValue).Msg("invalid payloadBlockValue")
 			elInfo.Error = fmt.Sprint(errBuf)
 			return elInfo
 		}
@@ -230,7 +230,7 @@ func (r *RewardEngine) calculateElRewardInfo(slotStats SlotStatsRecord, groupedB
 	})
 
 	secondHighest := sortable[len(sortable)-1]
-	winVal, ok := new(big.Float).SetString(slotStats.PayloadBlockValue)
+	winVal, ok := new(big.Float).SetString(slotStats.HeaderBlockValue)
 	if !ok {
 		errBuf = append(errBuf, "invalid payloadBlockValue")
 		r.logger.Warn().Uint64("slot", slotStats.Slot).Str("payloadBlockValue", slotStats.PayloadBlockValue).Msg("invalid payloadBlockValue")
@@ -311,6 +311,7 @@ func (r *RewardEngine) logRecord(record ElRewardInfo, proposerSendTimeUnixMS str
 		Str("proposerSendTimeUnixMS", proposerSendTimeUnixMS).
 		Str("err", record.Error).
 		Str("blockHash", record.BlockHash).
+		Float64("blockValue", record.OnchainBidValue).
 		Float64("elRewardIncreaseEth", record.ElRewardIncreaseEth).
 		Bool("isProxyWin", record.IsProxyWin).
 		Msg("emit el reward event")

--- a/el_reward_engine.go
+++ b/el_reward_engine.go
@@ -46,6 +46,8 @@ type DataHeader struct {
 }
 
 type ElRewardInfo struct {
+	ValidatorID                     string                  `json:"validator_id"`
+	AccountID                       string                  `json:"account_id"`
 	Slot                            string                  `json:"slot"`
 	SlotUID                         string                  `json:"slot_uid"`
 	BlockNumber                     string                  `json:"block_number"`
@@ -83,7 +85,7 @@ func (r *RewardEngine) Start(ctx context.Context) {
 		case slotStats := <-r.slotStartRecordCh:
 			bids := r.collectExternalRelayBids(slotStats.Slot)
 			reward := r.calculateElRewardInfo(slotStats, bids)
-			r.logRecord(reward)
+			r.logRecord(reward, slotStats.HeaderStartTimeUnixMs)
 		case <-ctx.Done():
 			return
 		}
@@ -156,6 +158,8 @@ func (r *RewardEngine) collectExternalRelayBids(slot uint64) map[string][]DataHe
 // TODO: Recovery option, move as a standalone script to calculate based on db and endpoints
 func (r *RewardEngine) calculateElRewardInfo(slotStats SlotStatsRecord, groupedBids map[string][]DataHeader) ElRewardInfo {
 	elInfo := ElRewardInfo{
+		ValidatorID:                     slotStats.ValidatorID,
+		AccountID:                       slotStats.AccountID,
 		Slot:                            fmt.Sprintf("%d", slotStats.Slot),
 		SlotUID:                         slotStats.HeaderSlotUID,
 		BlockHash:                       slotStats.PayloadDeliveredBlockHash,
@@ -299,9 +303,13 @@ func feeFor(percent uint64, uplift float64) float64 {
 	return 0.0
 }
 
-func (r *RewardEngine) logRecord(record ElRewardInfo) {
+func (r *RewardEngine) logRecord(record ElRewardInfo, proposerSendTimeUnixMS string) {
 	r.logger.Info().
 		Str("slotKey", record.Slot).
+		Str("validatorID", record.ValidatorID).
+		Str("accountID", record.AccountID).
+		Str("proposerSendTimeUnixMS", proposerSendTimeUnixMS).
+		Str("err", record.Error).
 		Str("blockHash", record.BlockHash).
 		Float64("elRewardIncreaseEth", record.ElRewardIncreaseEth).
 		Bool("isProxyWin", record.IsProxyWin).

--- a/el_reward_engine.go
+++ b/el_reward_engine.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math"
 	"math/big"
 	"net/http"
 	"net/url"
@@ -175,6 +176,7 @@ func (r *RewardEngine) calculateElRewardInfo(slotStats SlotStatsRecord, groupedB
 			if bid.BlockHash == slotStats.PayloadDeliveredBlockHash {
 				// this could be empty if max profit or regulated r-proxy delivered the bid
 				elInfo.OnchainBidDeliveredRelay = append(elInfo.OnchainBidDeliveredRelay, bid.RelayURL)
+				elInfo.BlockNumber = bid.BlockNumber
 			}
 			if bid.ProposerSendTimestampMs == slotStats.HeaderStartTimeUnixMs {
 				matchedBids = append(matchedBids, bid)
@@ -182,15 +184,13 @@ func (r *RewardEngine) calculateElRewardInfo(slotStats SlotStatsRecord, groupedB
 		}
 	}
 
-	// If relay proxy lost the block, no need calculate el reward increase
+	// If relay proxy lost a block, el reward increase calculation not needed
 	if !elInfo.IsProxyWin {
-		winVal := new(big.Float)
-		if _, ok := winVal.SetString(slotStats.PayloadBlockValue); !ok {
+		winVal, ok := new(big.Float).SetString(slotStats.PayloadBlockValue)
+		if !ok {
 			errBuf = append(errBuf, "invalid payloadBlockValue")
-			r.logger.Warn().
-				Uint64("slot", slotStats.Slot).
-				Str("blockValue", slotStats.PayloadBlockValue).
-				Msg("invalid payloadBlockValue")
+			r.logger.Warn().Uint64("slot", slotStats.Slot).Str("blockValue", slotStats.PayloadBlockValue).Msg("invalid payloadBlockValue")
+			elInfo.Error = fmt.Sprint(errBuf)
 			return elInfo
 		}
 		onchainFloat, _ := winVal.Float64()
@@ -200,48 +200,45 @@ func (r *RewardEngine) calculateElRewardInfo(slotStats SlotStatsRecord, groupedB
 	}
 
 	if len(matchedBids) < 2 {
+		elInfo.Error = "not enough matched bids"
 		return elInfo
 	}
 
-	sort.SliceStable(matchedBids, func(i, j int) bool {
-		iVal, iOk := new(big.Float).SetString(matchedBids[i].ValueEth)
-		if !iOk {
-			errBuf = append(errBuf, fmt.Sprintf("invalid iVal.ValueEth: %s", matchedBids[i].ValueEth))
+	type sortableBid struct {
+		DataHeader
+		Value *big.Float
+	}
+	var sortable []sortableBid
+	for _, bid := range matchedBids {
+		val, ok := new(big.Float).SetString(bid.ValueEth)
+		if !ok {
+			errBuf = append(errBuf, fmt.Sprintf("invalid bid valueEth: %s", bid.ValueEth))
+			continue
 		}
-		jVal, jOk := new(big.Float).SetString(matchedBids[j].ValueEth)
-		if !jOk {
-			errBuf = append(errBuf, fmt.Sprintf("invalid jVal.ValueEth: %s", matchedBids[j].ValueEth))
-		}
-		return iVal.Cmp(jVal) < 0
+		sortable = append(sortable, sortableBid{bid, val})
+	}
+	if len(sortable) < 1 {
+		elInfo.Error = "no valid matched bids with numeric value"
+		return elInfo
+	}
+	sort.SliceStable(sortable, func(i, j int) bool {
+		return sortable[i].Value.Cmp(sortable[j].Value) < 0
 	})
 
-	secondHighest := matchedBids[len(matchedBids)-1]
-
-	winVal := new(big.Float)
-	if _, ok := winVal.SetString(slotStats.PayloadBlockValue); !ok {
+	secondHighest := sortable[len(sortable)-1]
+	winVal, ok := new(big.Float).SetString(slotStats.PayloadBlockValue)
+	if !ok {
 		errBuf = append(errBuf, "invalid payloadBlockValue")
-		r.logger.Warn().
-			Uint64("slot", slotStats.Slot).
-			Str("payloadBlockValue", slotStats.PayloadBlockValue).
-			Msg("invalid payloadBlockValue")
+		r.logger.Warn().Uint64("slot", slotStats.Slot).Str("payloadBlockValue", slotStats.PayloadBlockValue).Msg("invalid payloadBlockValue")
+		elInfo.Error = fmt.Sprint(errBuf)
 		return elInfo
 	}
 
-	secondVal := new(big.Float)
-	if _, ok := secondVal.SetString(secondHighest.ValueEth); !ok {
-		errBuf = append(errBuf, fmt.Sprintf("invalid secondHighest.ValueEth: %s", secondHighest.ValueEth))
-		r.logger.Warn().
-			Uint64("slot", slotStats.Slot).
-			Str("secondHighestValueEth", secondHighest.ValueEth).
-			Msg("invalid secondHighestValueEth")
-		return elInfo
-	}
-
-	increase := new(big.Float).Sub(winVal, secondVal)
+	increase := new(big.Float).Sub(winVal, secondHighest.Value)
 	percentPrecise := new(big.Float).Quo(increase, winVal)
 	percentPrecise.Mul(percentPrecise, big.NewFloat(100))
 
-	isEqual := winVal.Cmp(secondVal) == 0
+	isEqual := winVal.Cmp(secondHighest.Value) == 0
 	elInfo.IsEqualToProxyBid = isEqual
 	if isEqual {
 		elInfo.IsProxyWin = false
@@ -249,7 +246,7 @@ func (r *RewardEngine) calculateElRewardInfo(slotStats SlotStatsRecord, groupedB
 	}
 
 	onchainFloat, _ := winVal.Float64()
-	secondFloat, _ := secondVal.Float64()
+	secondFloat, _ := secondHighest.Value.Float64()
 	incFloat, _ := increase.Float64()
 	percentFloat, _ := percentPrecise.Float64()
 
@@ -257,45 +254,49 @@ func (r *RewardEngine) calculateElRewardInfo(slotStats SlotStatsRecord, groupedB
 	elInfo.SecondHighestBidValue = secondFloat
 	elInfo.ElRewardIncreaseEth = incFloat
 	elInfo.ElRewardIncreasePercentPrecise = percentFloat
-	elInfo.ElRewardIncreasePercentage = uint64(percentFloat + 0.5)
-
+	elInfo.ElRewardIncreasePercentage = uint64(math.Round(percentFloat))
 	elInfo.SecondHighestBidDeliveredRelay = append(elInfo.SecondHighestBidDeliveredRelay, secondHighest.RelayURL)
 
 	weiFactor := new(big.Float).SetFloat64(1e18)
 	elRewardWei := new(big.Float).Mul(increase, weiFactor)
 	elRewardWei.Int(elInfo.ElRewardIncreaseWei)
 
+	elInfo.FeePerBlock = feeFor(elInfo.ElRewardIncreasePercentage, elInfo.ElRewardIncreaseEth)
+	elInfo.IsWinningBidHighest = len(sortable) > 0 && winVal.Cmp(sortable[len(sortable)-1].Value) >= 0
+	elInfo.Error = fmt.Sprint(errBuf)
+	return elInfo
+}
+
+func feeFor(percent uint64, uplift float64) float64 {
 	switch {
-	case elInfo.ElRewardIncreasePercentage <= 1:
-		elInfo.FeePerBlock = 0.0
-	case elInfo.ElRewardIncreasePercentage <= 5:
-		if elInfo.ElRewardIncreaseEth >= 0.0015 {
-			elInfo.FeePerBlock = 0.0015
+	case percent <= 1:
+		return 0.0
+	case percent <= 5:
+		if uplift >= 0.0015 {
+			return 0.0015
 		}
-	case elInfo.ElRewardIncreasePercentage <= 9:
+	case percent <= 9:
 		switch {
-		case elInfo.ElRewardIncreaseEth > 0.003:
-			elInfo.FeePerBlock = 0.003
-		case elInfo.ElRewardIncreaseEth > 0.0015:
-			elInfo.FeePerBlock = 0.0015
+		case uplift > 0.003:
+			return 0.003
+		case uplift > 0.0015:
+			return 0.0015
 		default:
-			elInfo.FeePerBlock = 0.0
+			return 0.0
 		}
 	default:
 		switch {
-		case elInfo.ElRewardIncreaseEth > 0.005:
-			elInfo.FeePerBlock = 0.005
-		case elInfo.ElRewardIncreaseEth > 0.003:
-			elInfo.FeePerBlock = 0.003
-		case elInfo.ElRewardIncreaseEth > 0.0015:
-			elInfo.FeePerBlock = 0.0015
+		case uplift > 0.005:
+			return 0.005
+		case uplift > 0.003:
+			return 0.003
+		case uplift > 0.0015:
+			return 0.0015
 		default:
-			elInfo.FeePerBlock = 0.0
+			return 0.0
 		}
 	}
-
-	elInfo.Error = fmt.Sprint(errBuf)
-	return elInfo
+	return 0.0
 }
 
 func (r *RewardEngine) logRecord(record ElRewardInfo) {

--- a/el_reward_engine.go
+++ b/el_reward_engine.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"math/big"
 	"net/http"
+	"net/url"
 	"sort"
 	"time"
 
@@ -27,7 +28,7 @@ type RewardEngine struct {
 	fluentd              fluentstats.Stats
 }
 
-type BidTrace struct {
+type DataHeader struct {
 	HeaderRequestID         string `json:"header_request_id"`
 	Slot                    string `json:"slot"`
 	ParentHash              string `json:"parent_hash"`
@@ -44,26 +45,27 @@ type BidTrace struct {
 }
 
 type ElRewardInfo struct {
-	Slot                           string                `json:"slot"`
-	SlotUID                        string                `json:"slot_uid"`
-	BlockNumber                    string                `json:"block_number"`
-	Bids                           map[string][]BidTrace `json:"bids"`
-	SelectedHeaderStartTimeUnixMs  string                `json:"selected_header_start_time_unix_ms"`
-	BlockHash                      string                `json:"block_hash"`
-	IsProxyWin                     bool                  `json:"is_proxy_win"`
-	IsWinningBidHighest            bool                  `json:"is_winning_bid_highest"`
-	ElRewardIncreaseWei            *big.Int              `json:"el_reward_increase_wei"`
-	ElRewardIncreaseEth            float64               `json:"el_reward_increase_eth"`
-	OnchainBidValue                float64               `json:"onchain_bid_value"`
-	SecondHighestBidValue          float64               `json:"second_highest_bid_value"`
-	OnchainBidDeliveredRelay       string                `json:"onchain_bid_delivered_relay"`
-	SecondHigherBidDeliveredRelay  string                `json:"second_higher_bid_delivered_relay"`
-	IsPayloadReceived              bool                  `json:"is_payload_received"`
-	ElRewardIncreasePercentage     uint64                `json:"el_reward_increase_percentage"`
-	ElRewardIncreasePercentPrecise float64               `json:"el_reward_increase_percent_precise"`
-	EqualToProxyBidders            string                `json:"equal_to_proxy_bidders"`
-	IsEqualToProxyBid              bool                  `json:"is_equal_to_proxy_bid"`
-	FeePerBlock                    float64               `json:"fee_per_block"`
+	Slot                            string                  `json:"slot"`
+	SlotUID                         string                  `json:"slot_uid"`
+	BlockNumber                     string                  `json:"block_number"`
+	Bids                            map[string][]DataHeader `json:"bids"`
+	SelectedProposerStartTimeUnixMs string                  `json:"selected_proposer_start_time_unix_ms"`
+	BlockHash                       string                  `json:"block_hash"`
+	IsProxyWin                      bool                    `json:"is_proxy_win"`
+	IsWinningBidHighest             bool                    `json:"is_winning_bid_highest"`
+	ElRewardIncreaseWei             *big.Int                `json:"el_reward_increase_wei"`
+	ElRewardIncreaseEth             float64                 `json:"el_reward_increase_eth"`
+	OnchainBidValue                 float64                 `json:"onchain_bid_value"`
+	SecondHighestBidValue           float64                 `json:"second_highest_bid_value"`
+	OnchainBidDeliveredRelay        []string                `json:"onchain_bid_delivered_relay"`
+	SecondHighestBidDeliveredRelay  []string                `json:"second_highest_bid_delivered_relay"`
+	IsPayloadReceived               bool                    `json:"is_payload_received"`
+	ElRewardIncreasePercentage      uint64                  `json:"el_reward_increase_percentage"`
+	ElRewardIncreasePercentPrecise  float64                 `json:"el_reward_increase_percent_precise"`
+	EqualToProxyBidders             string                  `json:"equal_to_proxy_bidders"`
+	IsEqualToProxyBid               bool                    `json:"is_equal_to_proxy_bid"`
+	FeePerBlock                     float64                 `json:"fee_per_block"`
+	Error                           string                  `json:"error"`
 }
 
 func NewElRewardEngine(opts ...RewardEngineOpts) *RewardEngine {
@@ -86,34 +88,58 @@ func (r *RewardEngine) Start(ctx context.Context) {
 		}
 	}
 }
-
-func (r *RewardEngine) collectExternalRelayBids(slot uint64) map[string][]BidTrace {
-	relayBids := make(map[string][]BidTrace)
+func (r *RewardEngine) collectExternalRelayBids(slot uint64) map[string][]DataHeader {
+	relayBids := make(map[string][]DataHeader)
 
 	for baseURL, apiKey := range r.relayUrlsWithApiKeys {
-		url := fmt.Sprintf("%s%s%d", baseURL, proposerHeaderDeliveredURI, slot)
-		req, err := http.NewRequest(http.MethodGet, url, nil)
+		// Validate baseURL
+		parsedURL, err := url.Parse(baseURL)
+		if err != nil || parsedURL.Scheme == "" || parsedURL.Host == "" {
+			r.logger.Error().Uint64("slot", slot).Str("relayURL", baseURL).Msg("invalid relay URL, skipping")
+			continue
+		}
+
+		fullURL := fmt.Sprintf("%s%s%d", baseURL, proposerHeaderDeliveredURI, slot)
+		req, err := http.NewRequest(http.MethodGet, fullURL, nil)
 		if err != nil {
-			r.logger.Error().Err(err).Str("url", baseURL).Msg("failed to create proposer header delivered request")
+			r.logger.Error().Err(err).Uint64("slot", slot).Str("url", fullURL).Msg("failed to create proposer header delivered request")
 			continue
 		}
 		req.Header.Set("X-API-Key", apiKey)
 		resp, err := r.httpClient.Do(req)
-		if err != nil || resp.StatusCode != http.StatusOK {
-			r.logger.Error().Err(err).Msgf("http request failed or returned non-200 from %s", baseURL)
+		if err != nil {
+			r.logger.Error().Err(err).Uint64("slot", slot).Str("url", fullURL).Msgf("http request failed to %s", fullURL)
+			continue
+		}
+		if resp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(resp.Body)
+			r.logger.Error().
+				Uint64("slot", slot).
+				Str("url", fullURL).
+				Int("statusCode", resp.StatusCode).
+				Str("body", string(body)).
+				Msg("non-200 response from relay")
+			resp.Body.Close()
 			continue
 		}
 
 		body, err := io.ReadAll(resp.Body)
-		resp.Body.Close()
+		errClose := resp.Body.Close()
 		if err != nil {
-			r.logger.Error().Err(err).Msg("failed to read body from relay")
+			r.logger.Error().Err(err).Uint64("slot", slot).Str("url", fullURL).Msg("failed to read body from relay")
 			continue
 		}
+		if errClose != nil {
+			r.logger.Warn().Err(errClose).Str("url", fullURL).Msg("error closing response body")
+		}
 
-		var bids []BidTrace
+		var bids []DataHeader
 		if err = json.Unmarshal(body, &bids); err != nil {
-			r.logger.Error().Err(err).Msg("failed to unmarshal bid trace")
+			r.logger.Error().Err(err).Uint64("slot", slot).Str("url", fullURL).Msg("failed to unmarshal data header")
+			continue
+		}
+		if len(bids) == 0 {
+			r.logger.Warn().Uint64("slot", slot).Str("url", fullURL).Msg("no bids received from relay")
 			continue
 		}
 		for i := range bids {
@@ -127,48 +153,94 @@ func (r *RewardEngine) collectExternalRelayBids(slot uint64) map[string][]BidTra
 }
 
 // TODO: Recovery option, move as a standalone script to calculate based on db and endpoints
-func (r *RewardEngine) calculateElRewardInfo(slotStats SlotStatsRecord, groupedBids map[string][]BidTrace) ElRewardInfo {
+func (r *RewardEngine) calculateElRewardInfo(slotStats SlotStatsRecord, groupedBids map[string][]DataHeader) ElRewardInfo {
 	elInfo := ElRewardInfo{
-		Slot:                          fmt.Sprintf("%d", slotStats.Slot),
-		SlotUID:                       slotStats.HeaderSlotUID,
-		BlockHash:                     slotStats.PayloadDeliveredBlockHash,
-		SelectedHeaderStartTimeUnixMs: slotStats.HeaderStartTimeUnixMs,
-		IsPayloadReceived:             slotStats.PayloadSucceeded,
-		IsProxyWin:                    slotStats.HeaderDeliveredBlockHash == slotStats.PayloadDeliveredBlockHash,
-		Bids:                          make(map[string][]BidTrace),
-		ElRewardIncreaseWei:           big.NewInt(0),
+		Slot:                            fmt.Sprintf("%d", slotStats.Slot),
+		SlotUID:                         slotStats.HeaderSlotUID,
+		BlockHash:                       slotStats.PayloadDeliveredBlockHash,
+		SelectedProposerStartTimeUnixMs: slotStats.HeaderStartTimeUnixMs,
+		IsPayloadReceived:               slotStats.PayloadSucceeded,
+		IsProxyWin:                      slotStats.HeaderDeliveredBlockHash == slotStats.PayloadDeliveredBlockHash,
+		Bids:                            make(map[string][]DataHeader),
+		ElRewardIncreaseWei:             big.NewInt(0),
+		OnchainBidDeliveredRelay:        make([]string, 0, 10),
+		SecondHighestBidDeliveredRelay:  make([]string, 0, 10),
 	}
 
-	var matchedBids []BidTrace
+	var matchedBids []DataHeader
+	var errBuf []string
 	for relayURL, bids := range groupedBids {
 		elInfo.Bids[relayURL] = bids
 		for _, bid := range bids {
+			if bid.BlockHash == slotStats.PayloadDeliveredBlockHash {
+				// this could be empty if max profit or regulated r-proxy delivered the bid
+				elInfo.OnchainBidDeliveredRelay = append(elInfo.OnchainBidDeliveredRelay, bid.RelayURL)
+			}
 			if bid.ProposerSendTimestampMs == slotStats.HeaderStartTimeUnixMs {
 				matchedBids = append(matchedBids, bid)
 			}
 		}
 	}
 
+	// If relay proxy lost the block, no need calculate el reward increase
+	if !elInfo.IsProxyWin {
+		winVal := new(big.Float)
+		if _, ok := winVal.SetString(slotStats.PayloadBlockValue); !ok {
+			errBuf = append(errBuf, "invalid payloadBlockValue")
+			r.logger.Warn().
+				Uint64("slot", slotStats.Slot).
+				Str("blockValue", slotStats.PayloadBlockValue).
+				Msg("invalid payloadBlockValue")
+			return elInfo
+		}
+		onchainFloat, _ := winVal.Float64()
+		elInfo.OnchainBidValue = onchainFloat
+		elInfo.Error = fmt.Sprint(errBuf)
+		return elInfo
+	}
+
 	if len(matchedBids) < 2 {
 		return elInfo
 	}
 
-	// Sort by value (ascending)
 	sort.SliceStable(matchedBids, func(i, j int) bool {
-		iVal, _ := new(big.Float).SetString(matchedBids[i].ValueEth)
-		jVal, _ := new(big.Float).SetString(matchedBids[j].ValueEth)
+		iVal, iOk := new(big.Float).SetString(matchedBids[i].ValueEth)
+		if !iOk {
+			errBuf = append(errBuf, fmt.Sprintf("invalid iVal.ValueEth: %s", matchedBids[i].ValueEth))
+		}
+		jVal, jOk := new(big.Float).SetString(matchedBids[j].ValueEth)
+		if !jOk {
+			errBuf = append(errBuf, fmt.Sprintf("invalid jVal.ValueEth: %s", matchedBids[j].ValueEth))
+		}
 		return iVal.Cmp(jVal) < 0
 	})
 
 	secondHighest := matchedBids[len(matchedBids)-1]
 
-	winVal, _ := new(big.Float).SetString(slotStats.PayloadBlockValue)
-	secondVal, _ := new(big.Float).SetString(secondHighest.ValueEth)
+	winVal := new(big.Float)
+	if _, ok := winVal.SetString(slotStats.PayloadBlockValue); !ok {
+		errBuf = append(errBuf, "invalid payloadBlockValue")
+		r.logger.Warn().
+			Uint64("slot", slotStats.Slot).
+			Str("payloadBlockValue", slotStats.PayloadBlockValue).
+			Msg("invalid payloadBlockValue")
+		return elInfo
+	}
+
+	secondVal := new(big.Float)
+	if _, ok := secondVal.SetString(secondHighest.ValueEth); !ok {
+		errBuf = append(errBuf, fmt.Sprintf("invalid secondHighest.ValueEth: %s", secondHighest.ValueEth))
+		r.logger.Warn().
+			Uint64("slot", slotStats.Slot).
+			Str("secondHighestValueEth", secondHighest.ValueEth).
+			Msg("invalid secondHighestValueEth")
+		return elInfo
+	}
+
 	increase := new(big.Float).Sub(winVal, secondVal)
 	percentPrecise := new(big.Float).Quo(increase, winVal)
 	percentPrecise.Mul(percentPrecise, big.NewFloat(100))
 
-	// Check if second best bid == winning bid
 	isEqual := winVal.Cmp(secondVal) == 0
 	elInfo.IsEqualToProxyBid = isEqual
 	if isEqual {
@@ -187,11 +259,12 @@ func (r *RewardEngine) calculateElRewardInfo(slotStats SlotStatsRecord, groupedB
 	elInfo.ElRewardIncreasePercentPrecise = percentFloat
 	elInfo.ElRewardIncreasePercentage = uint64(percentFloat + 0.5)
 
+	elInfo.SecondHighestBidDeliveredRelay = append(elInfo.SecondHighestBidDeliveredRelay, secondHighest.RelayURL)
+
 	weiFactor := new(big.Float).SetFloat64(1e18)
 	elRewardWei := new(big.Float).Mul(increase, weiFactor)
 	elRewardWei.Int(elInfo.ElRewardIncreaseWei)
 
-	//TODO: Perform fee per block calculation only certain accountID
 	switch {
 	case elInfo.ElRewardIncreasePercentage <= 1:
 		elInfo.FeePerBlock = 0.0
@@ -220,18 +293,20 @@ func (r *RewardEngine) calculateElRewardInfo(slotStats SlotStatsRecord, groupedB
 			elInfo.FeePerBlock = 0.0
 		}
 	}
+
+	elInfo.Error = fmt.Sprint(errBuf)
 	return elInfo
 }
 
 func (r *RewardEngine) logRecord(record ElRewardInfo) {
 	r.logger.Info().
 		Str("slotKey", record.Slot).
-		Str("blockHah", record.BlockHash).
-		Float64("blockHah", record.ElRewardIncreaseEth).
+		Str("blockHash", record.BlockHash).
+		Float64("elRewardIncreaseEth", record.ElRewardIncreaseEth).
 		Bool("isProxyWin", record.IsProxyWin).
 		Msg("emit el reward event")
 	r.fluentd.LogToFluentD(fluentstats.Record{
-		Type: TypeRelayProxySlotStats,
+		Type: TypeRelayProxyElReward,
 		Data: record,
 	}, time.Now().UTC(), r.nodeID, StatsRelayProxyElReward)
 }

--- a/el_reward_engine.go
+++ b/el_reward_engine.go
@@ -79,8 +79,9 @@ func (r *RewardEngine) Start(ctx context.Context) {
 		case slotStats := <-r.slotStartRecordCh:
 			bids := r.collectExternalRelayBids(slotStats.Slot)
 			reward := r.calculateElRewardInfo(slotStats, bids)
-			r.logger.Info().Msgf("calculated EL reward: %v", reward) //TODO:omit bids while logging to avoid cluttering
-		default:
+			r.logRecord(reward)
+		case <-ctx.Done():
+			return
 		}
 	}
 }

--- a/opts.go
+++ b/opts.go
@@ -289,6 +289,14 @@ func WithMiniProposerSlotMapSvc(miniProposerSlotMap *SyncMap[uint64, *common.Min
 	}
 }
 
+func WithSlotStatsRecordCh(ch chan SlotStatsRecord) ServiceOption {
+	return func(s *Service) {
+		s.slotStatsRecordCh = ch
+	}
+}
+
+// data service options
+
 func WithDataService(ds *DataService) ServiceOption {
 	return func(s *Service) {
 		s.IDataService = ds
@@ -414,5 +422,42 @@ func WithPlugin(customDelayer func(accountID string, msIntoSlot int64, cluster s
 func WithMiniProposerSlotMap(miniProposerSlotMap *SyncMap[uint64, *common.MiniValidatorLatency]) DataServiceOption {
 	return func(s *DataService) {
 		s.miniProposerSlotMap = miniProposerSlotMap
+	}
+}
+
+type RewardEngineOpts func(s *RewardEngine)
+
+func WithRewardEngineLogger(l zerolog.Logger) RewardEngineOpts {
+	return func(s *RewardEngine) {
+		s.logger = l
+	}
+}
+
+func WithRewardEngineHttpClient(c *http.Client) RewardEngineOpts {
+	return func(s *RewardEngine) {
+		s.httpClient = c
+	}
+}
+
+func WithRewardEngineSlotStatsRecordCh(ch chan SlotStatsRecord) RewardEngineOpts {
+	return func(s *RewardEngine) {
+		s.slotStartRecordCh = ch
+	}
+}
+
+func WithRewardEngineRelayUrlsWithApiKey(urlWithApiKeys map[string]string) RewardEngineOpts {
+	return func(s *RewardEngine) {
+		s.relayUrlsWithApiKeys = urlWithApiKeys
+	}
+}
+func WithRewardEngineNodeID(nodeID string) RewardEngineOpts {
+	return func(s *RewardEngine) {
+		s.nodeID = nodeID
+	}
+}
+
+func WithRewardEngineFluentd(f fluentstats.Stats) RewardEngineOpts {
+	return func(r *RewardEngine) {
+		r.fluentd = f
 	}
 }

--- a/opts.go
+++ b/opts.go
@@ -291,7 +291,7 @@ func WithMiniProposerSlotMapSvc(miniProposerSlotMap *SyncMap[uint64, *common.Min
 
 func WithSlotStatsRecordCh(ch chan SlotStatsRecord) ServiceOption {
 	return func(s *Service) {
-		s.slotStatsRecordCh = ch
+		s.slotStatsRecordForElRewardEngineCh = ch
 	}
 }
 

--- a/service.go
+++ b/service.go
@@ -123,7 +123,7 @@ type Service struct {
 	gatewayAuthKey               string
 	blockPublishFunc             func(tracer trace.Tracer, logger zerolog.Logger, payloadInfo *common.VersionedPayloadInfo, signedBeaconBlock *common.VersionedSignedBlindedBeaconBlock, blockPublishingGatewayClient interface{}, authKey string)
 	// slot stats record channel for reward engine
-	slotStatsRecordCh chan SlotStatsRecord
+	slotStatsRecordForElRewardEngineCh chan SlotStatsRecord
 }
 
 type slotStatsEvent struct {
@@ -2841,6 +2841,17 @@ func (s *Service) handleStreamBuilderInfoResponse(
 }
 
 func (s *Service) logRecord(record SlotStatsRecord, slotKey string, userAgent string) {
+	go func() {
+		for {
+			select {
+			case s.slotStatsRecordForElRewardEngineCh <- record:
+				return
+			default:
+				// retry after a second
+				time.Sleep(time.Second)
+			}
+		}
+	}()
 	s.slotStats.Get(slotKey)
 	s.logger.Info().
 		Str("slotKey", slotKey).

--- a/service.go
+++ b/service.go
@@ -116,13 +116,14 @@ type Service struct {
 
 	builderInfo *cache.Cache
 
-	accountsLists       *AccountsLists
-	walletAccounts      *map[string]*common.WalletAccount
-	miniProposerSlotMap *SyncMap[uint64, *common.MiniValidatorLatency]
-
+	accountsLists                *AccountsLists
+	walletAccounts               *map[string]*common.WalletAccount
+	miniProposerSlotMap          *SyncMap[uint64, *common.MiniValidatorLatency]
 	blockPublishingGatewayClient interface{}
 	gatewayAuthKey               string
 	blockPublishFunc             func(tracer trace.Tracer, logger zerolog.Logger, payloadInfo *common.VersionedPayloadInfo, signedBeaconBlock *common.VersionedSignedBlindedBeaconBlock, blockPublishingGatewayClient interface{}, authKey string)
+	// slot stats record channel for reward engine
+	slotStatsRecordCh chan SlotStatsRecord
 }
 
 type slotStatsEvent struct {
@@ -1853,8 +1854,7 @@ func (s *Service) sendPayloadStats(payload []byte, log *zerolog.Logger, isSuccee
 	}
 	var (
 		isRelayProxyWin bool
-		//isSlotUIDMatch  bool
-		fallback SlotStatsRecord
+		fallback        SlotStatsRecord
 	)
 	k := fmt.Sprintf("slot-%v-parentHash-%v", out.GetSlot(), out.GetParentHash())
 	v, ok := s.slotStats.Get(k)
@@ -1867,7 +1867,6 @@ func (s *Service) sendPayloadStats(payload []byte, log *zerolog.Logger, isSuccee
 				if record.HeaderDeliveredBlockHash == out.GetBlockHash() {
 					mergeSlotStats(&record, &statsRecord)
 					isRelayProxyWin = true
-					//isSlotUIDMatch = record.HeaderSlotUID == statsRecord.PayloadSlotUID
 					break
 				}
 				if !isRelayProxyWin {

--- a/stats.go
+++ b/stats.go
@@ -12,6 +12,7 @@ const (
 	StatsRelayProxyHeaderStreamReceived   = "stats.relay-proxy-headerStreamReceived"
 	StatsRelayProxyBlockStreamReceived    = "stats.relay-proxy-blockStreamReceived"
 	StatsRelayProxyGetHeaderExternalRelay = "stats.relay-proxy-getHeader-externalRelay"
+	StatsRelayProxyElReward               = "stats.relay-proxy-el-reward"
 
 	TypeRelayProxyGetHeader              = "relay_proxy_provided_header"
 	TypeRelayProxyGetPayload             = "relay_proxy_provided_payload"

--- a/stats.go
+++ b/stats.go
@@ -21,6 +21,7 @@ const (
 	TypeRelayProxyHeaderStreamReceived   = "relay_proxy_header_stream_received"
 	TypeRelayProxyGetHeaderExternalRelay = "relay_proxy_external_relay_header"
 	TypeRelayProxyBlockStreamReceived    = "relay_proxy_block_stream_received"
+	TypeRelayProxyElReward               = "relay_proxy_el_reward"
 )
 
 type HeaderStreamReceivedRecord struct {


### PR DESCRIPTION
## 📝 Summary
Perform El reward calculation in real time using bids provided by data endpoints

## 💡 Motivation and Context

<!--- (Optional) Why is this change required? What problem does it solve? Remove this section if not applicable. -->

---
Currently El reward calculations are performed based on received validator logs, instead El reward calcuation will be performed based on provided bids in live via data endpoints supported by other relays
## ✅ I have completed the following steps:

* [x] Run `make lint`
* [ ] Run `make test`
* [x] Run `go mod tidy`
* [ ] Added tests (if applicable)
