### PR TITLE
Hotfix Stats Table

### DIFF
--- a/server.go
+++ b/server.go
@@ -795,12 +795,14 @@ func (s *Server) HandleGetPayload(w http.ResponseWriter, r *http.Request) {
 			SlotUID:                   headerSlotUID,
 		})
 	}
+	_, mergeLogMetric := s.tracer.Start(getPayloadCtx, "handleGetPayload-mergeLogMetric")
 	logMetric.Merge(lm)
 	if err != nil {
 		span.SetStatus(codes.Error, err.Error())
 		respondError(getPayloadCtx, getPayload, w, err, s.logger, s.tracer, logMetric)
 		return
 	}
+	mergeLogMetric.End()
 
 	// If successful, execute the 'OnPayloadDelivered' callback after the function returns.
 	success := &atomic.Bool{}
@@ -825,6 +827,7 @@ func (s *Server) HandleGetPayload(w http.ResponseWriter, r *http.Request) {
 		respondOK(getPayloadCtx, getPayload, w, versionedPayloadInfo.GetResponse(), s.logger, s.tracer, logMetric)
 		return
 	}
+	_, marshalUnmarshalSpan := s.tracer.Start(getPayloadCtx, "handleGetPayload-marshalUnmarshal")
 	payloadResponse := new(common.VersionedSubmitBlindedBlockResponse)
 	if err := payloadResponse.UnmarshalJSON(versionedPayloadInfo.GetResponse()); err != nil {
 		span.SetStatus(codes.Error, err.Error())
@@ -839,7 +842,7 @@ func (s *Server) HandleGetPayload(w http.ResponseWriter, r *http.Request) {
 		respondOK(getPayloadCtx, getPayload, w, versionedPayloadInfo.GetResponse(), s.logger, s.tracer, logMetric)
 		return
 	}
-
+	marshalUnmarshalSpan.End()
 	w.Header().Set(common.HeaderEthConsensusVersion, payloadResponse.Version.String())
 	s.respondOKWithContextSSZMarshalled(getPayloadCtx, getPayload, w, outByte, s.logger, s.tracer, logMetric)
 }

--- a/service.go
+++ b/service.go
@@ -1923,16 +1923,18 @@ func (s *Service) sendPayloadStats(payload []byte, logMetric *LogMetric, isSucce
 					fallback = record
 				}
 				if record.HeaderDeliveredBlockHash == out.GetBlockHash() {
-					mergeSlotStats(record, statsRecord)
+					mergeSlotStats(&record, &statsRecord)
 					isRelayProxyWin = true
 					//isSlotUIDMatch = record.HeaderSlotUID == statsRecord.PayloadSlotUID
 					break
 				}
 				if !isRelayProxyWin {
-					mergeSlotStats(fallback, statsRecord)
+					mergeSlotStats(&fallback, &statsRecord)
 				}
 			}
 		}
+	} else {
+		s.logger.Warn().Str("slotKey", k).Msg("no previous slot stats found, creating new record")
 	}
 	s.slotStatsEvent.Set(k, statsRecord, cache.DefaultExpiration) // replace with updated slot stats
 
@@ -1969,7 +1971,7 @@ func (s *Service) sendPayloadStats(payload []byte, logMetric *LogMetric, isSucce
 		Data: payloadStats,
 	}, time.Now().UTC(), s.nodeID, StatsRelayProxyGetPayload)
 }
-func mergeSlotStats(record SlotStatsRecord, statsRecord SlotStatsRecord) SlotStatsRecord {
+func mergeSlotStats(record *SlotStatsRecord, statsRecord *SlotStatsRecord) {
 	statsRecord.HeaderReqID = record.HeaderReqID
 	statsRecord.HeaderReqReceivedAt = record.HeaderReqReceivedAt
 	statsRecord.HeaderReqDuration = record.HeaderReqDuration
@@ -1989,7 +1991,7 @@ func mergeSlotStats(record SlotStatsRecord, statsRecord SlotStatsRecord) SlotSta
 
 	statsRecord.AccountID = record.AccountID
 	statsRecord.ValidatorID = record.ValidatorID
-	return statsRecord
+	return
 }
 
 func (s *Service) keyForCachingBids(slot uint64, parentHash string, proposerPubkey string) string {


### PR DESCRIPTION
## 📝 Summary

The data table for rproxy is corrupted
![image](https://github.com/user-attachments/assets/fa99952b-64ba-46ec-ad11-b7ed31d97c6e)
this is due to records being copied and modified rather than having the reference to the record modified. 


Fix:

![image](https://github.com/user-attachments/assets/22a5202c-33ff-4759-9939-9789fdb53ec5)

## 💡 Motivation and Context

<!--- (Optional) Why is this change required? What problem does it solve? Remove this section if not applicable. -->

---

## ✅ I have completed the following steps:

* [ ] Run `make lint`
* [ ] Run `make test`
* [ ] Run `go mod tidy`
* [ ] Added tests (if applicable)
