### PR TITLE
trusted validator handle both cache value and calling relay respon fo…

### DIFF
--- a/service.go
+++ b/service.go
@@ -521,7 +521,7 @@ func (s *Service) StreamHeader(ctx context.Context, client *common.Client, paren
 				"source":     source,
 			})
 
-			s.logger.Warn().Fields(lm.GetFields()).Msg("block hash already exist")
+			s.logger.Debug().Fields(lm.GetFields()).Msg("block hash already exist")
 			continue
 		}
 		// update block hash map if not seen already
@@ -537,9 +537,9 @@ func (s *Service) StreamHeader(ctx context.Context, client *common.Client, paren
 			"streamLatencyInMs": time.Since(header.GetSendTime().AsTime()).Milliseconds(),
 		})
 
-		s.logger.Info().Fields(lm.GetFields()).Msg("received header")
+		s.logger.Debug().Fields(lm.GetFields()).Msg("received header")
 
-		headerStream := HeaderStreamReceivedRecord{
+		_ = HeaderStreamReceivedRecord{
 			RelayReceivedAt:   header.GetRelayReceiveTime().AsTime(),
 			ReceivedAt:        receivedAt,
 			SentAt:            header.GetSendTime().AsTime(),
@@ -559,12 +559,12 @@ func (s *Service) StreamHeader(ctx context.Context, client *common.Client, paren
 			PayloadFetchUrl:   header.GetPayloadFetchUrl(),
 		}
 
-		go func(streamCopy HeaderStreamReceivedRecord) {
-			s.fluentD.LogToFluentD(fluentstats.Record{
-				Type: TypeRelayProxyHeaderStreamReceived,
-				Data: streamCopy,
-			}, time.Now().UTC(), s.nodeID, StatsRelayProxyHeaderStreamReceived)
-		}(headerStream)
+		//go func(streamCopy HeaderStreamReceivedRecord) {
+		//	s.fluentD.LogToFluentD(fluentstats.Record{
+		//		Type: TypeRelayProxyHeaderStreamReceived,
+		//		Data: streamCopy,
+		//	}, time.Now().UTC(), s.nodeID, StatsRelayProxyHeaderStreamReceived)
+		//}(headerStream)
 
 		// Store the bid for builder pubkey
 		_, storeBidsSpan := s.tracer.Start(streamReceiveCtx, "StreamHeader-storeBids")

--- a/service.go
+++ b/service.go
@@ -1595,20 +1595,7 @@ func (s *Service) GetPayloadTrusted(ctx context.Context, log *zerolog.Logger, in
 		ReceivedAt:  timestamppb.New(in.ReceivedAt),
 		SecretToken: s.secretToken,
 	}
-	for _, client := range s.clients {
-		go func(c *common.ParentClient) {
-			_, err := s.getPayloadWithRetry(ctx, c.SafeClient, span, req, maxGetPayloadRetry)
-			if err != nil {
-				log.Error().Err(err).Msg("getPayloadWithRetry")
-				return
-			}
-			log.Info().Msg("getPayloadWithRetry success")
-		}(client)
-	}
 	timeToRelayRequestSpan.End()
-
-	_, payloadResponseSpan := s.tracer.Start(ctx, "getPayload-fastPath")
-	defer payloadResponseSpan.End()
 
 	blindedBeaconBlock, errRes := s.prefetchPayloadToSignedBlindedBeaconBlock(ctx, in.Payload)
 	if errRes != nil {
@@ -1617,72 +1604,61 @@ func (s *Service) GetPayloadTrusted(ctx context.Context, log *zerolog.Logger, in
 		return nil, errRes
 	}
 
-	slot, err := blindedBeaconBlock.Slot()
-	if err != nil {
-		return nil, toErrorResp(http.StatusBadRequest, "failed to get slot")
-	}
-	blockHash, err := blindedBeaconBlock.ExecutionBlockHash()
-	if err != nil {
-		return nil, toErrorResp(http.StatusBadRequest, "failed to get block hash")
-	}
-	parentHash, err := blindedBeaconBlock.ExecutionParentHash()
-	if err != nil {
-		return nil, toErrorResp(http.StatusBadRequest, "failed to get parent hash")
-	}
-	slotInt := int64(slot)
-	blockHashStr := blockHash.String()
-	parentHashStr := parentHash.String()
-	uKey := fmt.Sprintf("slot_%v_bHash_%v_pHash_%v", slotInt, blockHashStr, parentHashStr)
+	payloadInfoChan := make(chan *common.VersionedPayloadInfo, 1)
 
-	parentSpan.SetAttributes(
-		attribute.Int64("slot", slotInt),
-		attribute.String("blockHash", blockHashStr),
-		attribute.String("parentHash", parentHashStr),
-		attribute.String("uniqueKey", uKey),
-	)
-	*log = log.With().
-		Int64("slot", slotInt).
-		Str("blockHash", blockHashStr).
-		Str("parentHash", parentHashStr).
-		Str("uniqueKey", uKey).
-		Logger()
-
-	payloadInfo, errRes := s.validateAndFetchPayload(ctx, blindedBeaconBlock)
-	if errRes != nil {
-		// TODO: wait for relay response
-		go s.sendPayloadStats(in.Payload, log, false, payloadInfo, in.ReceivedAt, startTime, time.Now(), 0, id, in.ClientIP, in.ValidatorID, in.AccountID, latency, in.Cluster, in.UserAgent, in.SlotUID)
-		return nil, errRes
-	}
-
-	// return immediately
-	slotStartTime := GetSlotStartTime(s.beaconGenesisTime, int64(payloadInfo.Slot), s.secondsPerSlot)
-	msIntoSlot := in.ReceivedAt.Sub(slotStartTime).Milliseconds()
-	duration := time.Since(startTime)
-
-	go s.sendPayloadStats(in.Payload, log, true, payloadInfo, in.ReceivedAt, startTime, slotStartTime, msIntoSlot, id, in.ClientIP, in.ValidatorID, in.AccountID, latency, in.Cluster, in.UserAgent, in.SlotUID)
-
-	*log = log.With().
-		Dur("duration", duration).
-		Int64("slotStartTime", slotStartTime.UnixMilli()).
-		Int64("msIntoSlot", msIntoSlot).
-		Str("blockValue", payloadInfo.BlockValue).
-		Logger()
-
-	parentSpan.SetAttributes(
-		attribute.String("duration", duration.String()),
-		attribute.Int64("slotStartTime", slotStartTime.UnixMilli()),
-		attribute.Int64("msIntoSlot", msIntoSlot),
-		attribute.String("blockValue", payloadInfo.BlockValue),
-	)
-
-	// publish block to gateway
-	go func(tracer trace.Tracer, logger zerolog.Logger, payloadInfo *common.VersionedPayloadInfo, signedBeaconBlock *common.VersionedSignedBlindedBeaconBlock, client interface{}, authKey string) {
-		if s.blockPublishFunc != nil {
-			s.blockPublishFunc(tracer, logger, payloadInfo, signedBeaconBlock, client, authKey)
+	// Start validateAndFetchPayload
+	go func() {
+		payloadInfo, err := s.validateAndFetchPayload(ctx, blindedBeaconBlock)
+		if err == nil {
+			select {
+			case payloadInfoChan <- payloadInfo:
+			default:
+			}
 		}
-	}(s.tracer, s.logger, payloadInfo, blindedBeaconBlock, s.blockPublishingGatewayClient, s.gatewayAuthKey)
+	}()
 
-	return payloadInfo, nil
+	// Send getPayloadWithRetry requests to all clients
+	for _, client := range s.clients {
+		go func(c *common.ParentClient) {
+			resp, err := s.getPayloadWithRetry(ctx, c.SafeClient, span, req, maxGetPayloadRetry)
+			if err == nil && resp != nil {
+				select {
+				case payloadInfoChan <- resp:
+				default:
+				}
+			}
+		}(client)
+	}
+
+	select {
+	case payloadInfo := <-payloadInfoChan:
+		slotStartTime := GetSlotStartTime(s.beaconGenesisTime, int64(payloadInfo.Slot), s.secondsPerSlot)
+		msIntoSlot := in.ReceivedAt.Sub(slotStartTime).Milliseconds()
+		duration := time.Since(startTime)
+		go s.sendPayloadStats(in.Payload, log, true, payloadInfo, in.ReceivedAt, startTime, slotStartTime, msIntoSlot, id, in.ClientIP, in.ValidatorID, in.AccountID, latency, in.Cluster, in.UserAgent, in.SlotUID)
+		*log = log.With().
+			Dur("duration", duration).
+			Int64("slotStartTime", slotStartTime.UnixMilli()).
+			Int64("msIntoSlot", msIntoSlot).
+			Str("blockValue", payloadInfo.BlockValue).
+			Logger()
+		parentSpan.SetAttributes(
+			attribute.String("duration", duration.String()),
+			attribute.Int64("slotStartTime", slotStartTime.UnixMilli()),
+			attribute.Int64("msIntoSlot", msIntoSlot),
+			attribute.String("blockValue", payloadInfo.BlockValue),
+		)
+		go func() {
+			if s.blockPublishFunc != nil {
+				s.blockPublishFunc(s.tracer, s.logger, payloadInfo, blindedBeaconBlock, s.blockPublishingGatewayClient, s.gatewayAuthKey)
+			}
+		}()
+		return payloadInfo, nil
+	case <-time.After(1 * time.Second):
+	}
+	log.Error().Msg("timeout waiting for payload response")
+	go s.sendPayloadStats(in.Payload, log, false, nil, in.ReceivedAt, startTime, time.Now(), 0, id, in.ClientIP, in.ValidatorID, in.AccountID, latency, in.Cluster, in.UserAgent, in.SlotUID)
+	return nil, toErrorResp(http.StatusOK, "pre fetch payload not available in cache after retries")
 }
 
 type ErrorRespWithPayload struct {

--- a/service.go
+++ b/service.go
@@ -908,13 +908,27 @@ func (s *Service) PreFetchGetPayload(ctx context.Context, fields preFetcherField
 	ctx = trace.ContextWithSpan(context.Background(), parentSpan)
 	ctx = metadata.AppendToOutgoingContext(ctx, "authorization", s.authKey)
 	spanctx, span := s.tracer.Start(ctx, "preFetchGetPayload-start")
-	defer span.End()
+	uKey := fmt.Sprintf("slot_%v_bHash_%v_pHash_%v", fields.slot, fields.blockHash, fields.parentHash)
+	defer func() {
+		span.SetAttributes(
+			attribute.String("method", preFetchPayload),
+			attribute.String("clientIP", fields.clientIP),
+			attribute.String("clientURL", clientURL),
+			attribute.String("reqID", id),
+			attribute.Int64("receivedAt", startTime.Unix()),
+			attribute.String("traceID", parentSpan.SpanContext().TraceID().String()),
+			attribute.String("authHeader", fields.authHeader),
+			attribute.String("secretToken", s.secretToken),
+			attribute.String("uKey", uKey),
+			attribute.Int64("slot", int64(fields.slot)),
+			attribute.String("blockHash", fields.blockHash),
+		)
+		span.End()
+	}()
 
 	if fields.client != nil {
 		clientURL = fields.client.SafeClient.URL
 	}
-
-	uKey := fmt.Sprintf("slot_%v_bHash_%v_pHash_%v", fields.slot, fields.blockHash, fields.parentHash)
 
 	logMetric := NewLogMetric(
 		map[string]any{
@@ -933,19 +947,6 @@ func (s *Service) PreFetchGetPayload(ctx context.Context, fields preFetcherField
 	)
 
 	s.logger.Info().Fields(logMetric.GetFields()).Msg("received preFetchGetPayload")
-	span.SetAttributes(
-		attribute.String("method", preFetchPayload),
-		attribute.String("clientIP", fields.clientIP),
-		attribute.String("clientURL", clientURL),
-		attribute.String("reqID", id),
-		attribute.Int64("receivedAt", startTime.Unix()),
-		attribute.String("traceID", parentSpan.SpanContext().TraceID().String()),
-		attribute.String("authHeader", fields.authHeader),
-		attribute.String("secretToken", s.secretToken),
-		attribute.String("uKey", uKey),
-		attribute.Int64("slot", int64(fields.slot)),
-		attribute.String("blockHash", fields.blockHash),
-	)
 
 	// If necessary, fetch the Optimistic V3 payload directly from the specified builder URL(s)
 	if fields.payloadFetchUrl != "" {
@@ -1123,15 +1124,16 @@ func (s *Service) clientPreFetchGetPayloadHTTP(
 	payloadUrls []string,
 ) bool {
 	_, fetchSpan := s.tracer.Start(ctx, "clientPreFetchGetPayloadHTTP")
-	defer fetchSpan.End()
-
-	fetchSpan.SetAttributes(
-		attribute.Int64("slot", int64(fields.slot)),
-		attribute.String("blockHash", fields.blockHash),
-		attribute.String("parentHash", fields.parentHash),
-		attribute.String("proposerPubkey", fields.proposerPubKey),
-		attribute.String("builderPubkey", fields.builderPubKey),
-	)
+	defer func() {
+		fetchSpan.SetAttributes(
+			attribute.Int64("slot", int64(fields.slot)),
+			attribute.String("blockHash", fields.blockHash),
+			attribute.String("parentHash", fields.parentHash),
+			attribute.String("proposerPubkey", fields.proposerPubKey),
+			attribute.String("builderPubkey", fields.builderPubKey),
+		)
+		fetchSpan.End()
+	}()
 
 	payload, err := s.prepareGetPayloadV3Request(fields.blockHash)
 	if err != nil {
@@ -1351,8 +1353,28 @@ func (s *Service) GetPayload(ctx context.Context, log *zerolog.Logger, in *Paylo
 	ctx = metadata.AppendToOutgoingContext(ctx, "authorization", s.authKey)
 
 	ctx, span := s.tracer.Start(ctx, "getPayload-start")
-	defer span.End()
-
+	var (
+		slotInt       int64
+		blockHashStr  string
+		parentHashStr string
+		blockValueStr string
+		uKey          string
+	)
+	defer func() {
+		_, logTimingSpan := s.tracer.Start(ctx, "getPayload-logTimingSpan")
+		parentSpan.SetAttributes(
+			attribute.String("method", getPayload),
+			attribute.String("reqID", id),
+			attribute.Int64("receivedAt", in.ReceivedAt.Unix()),
+			attribute.Int64("slot", slotInt),
+			attribute.String("blockHash", blockHashStr),
+			attribute.String("parentHash", parentHashStr),
+			attribute.String("blockValue", blockValueStr),
+			attribute.String("uniqueKey", uKey),
+		)
+		logTimingSpan.End()
+		span.End()
+	}()
 	_, timeToRelayRequestSpan := s.tracer.Start(ctx, "getPayload-TimeToRelayRequest")
 
 	var latency int64
@@ -1421,17 +1443,11 @@ func (s *Service) GetPayload(ctx context.Context, log *zerolog.Logger, in *Paylo
 			errChan <- ErrorRespWithPayload{err: toErrorResp(http.StatusBadRequest, "failed to get parent hash"), resp: nil}
 			return
 		}
-		slotInt := int64(slot)
-		blockHashStr := blockHash.String()
-		parentHashStr := parentHash.String()
-		uKey := fmt.Sprintf("slot_%v_bHash_%v_pHash_%v", slotInt, blockHashStr, parentHashStr)
+		slotInt = int64(slot)
+		blockHashStr = blockHash.String()
+		parentHashStr = parentHash.String()
+		uKey = fmt.Sprintf("slot_%v_bHash_%v_pHash_%v", slotInt, blockHashStr, parentHashStr)
 
-		parentSpan.SetAttributes(
-			attribute.Int64("slot", slotInt),
-			attribute.String("blockHash", blockHashStr),
-			attribute.String("parentHash", parentHashStr),
-			attribute.String("uniqueKey", uKey),
-		)
 		*log = log.With().
 			Int64("slot", slotInt).
 			Str("blockHash", blockHashStr).
@@ -1505,7 +1521,8 @@ func (s *Service) GetPayload(ctx context.Context, log *zerolog.Logger, in *Paylo
 
 			go s.sendPayloadStats(in.Payload, log, true, resp, in.ReceivedAt, startTime, slotStartTime, msIntoSlot, id, in.ClientIP, in.ValidatorID, in.AccountID, latency, in.Cluster, in.UserAgent, in.SlotUID)
 
-			uKey := fmt.Sprintf("slot_%v_bHash_%v_pHash_%v", resp.Slot, resp.BlockHash, resp.ParentHash)
+			uKey = fmt.Sprintf("slot_%v_bHash_%v_pHash_%v", resp.Slot, resp.BlockHash, resp.ParentHash)
+			blockValueStr = resp.BlockValue
 			*log = log.With().
 				Dur("duration", duration).
 				Int64("slot", int64(resp.Slot)).
@@ -1516,16 +1533,6 @@ func (s *Service) GetPayload(ctx context.Context, log *zerolog.Logger, in *Paylo
 				Str("blockValue", resp.BlockValue).
 				Str("uniqueKey", uKey).
 				Logger()
-			parentSpan.SetAttributes(
-				attribute.String("duration", duration.String()),
-				attribute.Int64("slot", int64(resp.Slot)),
-				attribute.Int64("slotStartTime", slotStartTime.UnixMilli()),
-				attribute.Int64("msIntoSlot", msIntoSlot),
-				attribute.String("parentHash", resp.ParentHash),
-				attribute.String("blockHash", resp.BlockHash),
-				attribute.String("blockValue", resp.BlockValue),
-				attribute.String("uniqueKey", uKey),
-			)
 			payloadResponseSpan.End()
 			return resp, nil
 
@@ -1557,21 +1564,6 @@ func (s *Service) GetPayloadTrusted(ctx context.Context, log *zerolog.Logger, in
 	}
 	ctx = metadata.AppendToOutgoingContext(ctx, "authorization", authKey)
 
-	ctx, span := s.tracer.Start(ctx, "getPayload-start")
-	defer span.End()
-
-	_, timeToRelayRequestSpan := s.tracer.Start(ctx, "getPayload-TimeToRelayRequest")
-
-	var latency int64
-	if in.GetPayloadStartTimeUnixMS != "" {
-		if getPayloadStartTime, err := strconv.ParseInt(in.GetPayloadStartTimeUnixMS, 10, 64); err == nil {
-			latency = in.ReceivedAt.Sub(time.UnixMilli(getPayloadStartTime)).Milliseconds()
-		} else {
-			log.Warn().Err(err).Msg("failed to parse getPayloadStartTimeUnixMS")
-		}
-	}
-
-	_, logTimingSpan := s.tracer.Start(ctx, "getPayload-logTimingSpan")
 	*log = log.With().
 		Str("method", getPayloadTrusted).
 		Time("receivedAt", in.ReceivedAt).
@@ -1579,13 +1571,42 @@ func (s *Service) GetPayloadTrusted(ctx context.Context, log *zerolog.Logger, in
 		Bool("isAuthHeaderProvided", in.AuthHeader != "").
 		Logger()
 	log.Info().Msg("received getPayloadTrusted")
-	parentSpan.SetAttributes(
-		attribute.String("method", getPayload),
-		attribute.String("reqID", id),
-		attribute.Int64("receivedAt", in.ReceivedAt.Unix()),
+	ctx, span := s.tracer.Start(ctx, "getPayload-start")
+	var (
+		slotInt       int64
+		blockHashStr  string
+		parentHashStr string
+		blockValueStr string
+		uKey          string
+		latency       int64
 	)
-	log.Info().Msg("added spans getPayloadTrusted")
-	logTimingSpan.End()
+	defer func() {
+		_, logTimingSpan := s.tracer.Start(ctx, "getPayload-logTimingSpan")
+		parentSpan.SetAttributes(
+			attribute.String("method", getPayloadTrusted),
+			attribute.String("reqID", id),
+			attribute.Int64("receivedAt", in.ReceivedAt.Unix()),
+			attribute.Int64("slot", slotInt),
+			attribute.String("blockHash", blockHashStr),
+			attribute.String("parentHash", parentHashStr),
+			attribute.String("blockValue", blockValueStr),
+			attribute.String("uniqueKey", uKey),
+			attribute.Int64("latency", latency),
+		)
+		log.Info().Msg("added spans getPayloadTrusted")
+		logTimingSpan.End()
+		span.End()
+	}()
+
+	_, timeToRelayRequestSpan := s.tracer.Start(ctx, "getPayload-TimeToRelayRequest")
+
+	if in.GetPayloadStartTimeUnixMS != "" {
+		if getPayloadStartTime, err := strconv.ParseInt(in.GetPayloadStartTimeUnixMS, 10, 64); err == nil {
+			latency = in.ReceivedAt.Sub(time.UnixMilli(getPayloadStartTime)).Milliseconds()
+		} else {
+			log.Warn().Err(err).Msg("failed to parse getPayloadStartTimeUnixMS")
+		}
+	}
 
 	req := &relaygrpc.GetPayloadRequest{
 		ReqId:       id,
@@ -1604,6 +1625,28 @@ func (s *Service) GetPayloadTrusted(ctx context.Context, log *zerolog.Logger, in
 		go s.sendPayloadStats(in.Payload, log, false, nil, in.ReceivedAt, startTime, time.Now(), 0, id, in.ClientIP, in.ValidatorID, in.AccountID, latency, in.Cluster, in.UserAgent, in.SlotUID)
 		return nil, errRes
 	}
+	slot, err := blindedBeaconBlock.Slot()
+	if err != nil {
+		return nil, toErrorResp(http.StatusBadRequest, "failed to get slot")
+	}
+	blockHash, err := blindedBeaconBlock.ExecutionBlockHash()
+	if err != nil {
+		return nil, toErrorResp(http.StatusBadRequest, "failed to get block hash")
+	}
+	parentHash, err := blindedBeaconBlock.ExecutionParentHash()
+	if err != nil {
+		return nil, toErrorResp(http.StatusBadRequest, "failed to get parent hash")
+	}
+	slotInt = int64(slot)
+	blockHashStr = blockHash.String()
+	parentHashStr = parentHash.String()
+	uKey = fmt.Sprintf("slot_%v_bHash_%v_pHash_%v", slotInt, blockHashStr, parentHashStr)
+	*log = log.With().
+		Int64("Slot", slotInt).
+		Str("blockHash", blockHashStr).
+		Str("parentHash", parentHashStr).
+		Str("uKey", uKey).
+		Logger()
 	prefetchPayloadToSignedBlindedBeaconBlockSpan.End()
 
 	payloadInfoChan := make(chan *common.VersionedPayloadInfo, 1)
@@ -1649,18 +1692,14 @@ func (s *Service) GetPayloadTrusted(ctx context.Context, log *zerolog.Logger, in
 		msIntoSlot := in.ReceivedAt.Sub(slotStartTime).Milliseconds()
 		duration := time.Since(startTime)
 		go s.sendPayloadStats(in.Payload, log, true, payloadInfo, in.ReceivedAt, startTime, slotStartTime, msIntoSlot, id, in.ClientIP, in.ValidatorID, in.AccountID, latency, in.Cluster, in.UserAgent, in.SlotUID)
+		blockValueStr = payloadInfo.GetBlockValue()
 		*log = log.With().
+			Int64("latency", latency).
 			Dur("duration", duration).
 			Int64("slotStartTime", slotStartTime.UnixMilli()).
 			Int64("msIntoSlot", msIntoSlot).
-			Str("blockValue", payloadInfo.BlockValue).
+			Str("blockValue", blockValueStr).
 			Logger()
-		parentSpan.SetAttributes(
-			attribute.String("duration", duration.String()),
-			attribute.Int64("slotStartTime", slotStartTime.UnixMilli()),
-			attribute.Int64("msIntoSlot", msIntoSlot),
-			attribute.String("blockValue", payloadInfo.BlockValue),
-		)
 		go func() {
 			if s.blockPublishFunc != nil {
 				s.blockPublishFunc(s.tracer, s.logger, payloadInfo, blindedBeaconBlock, s.blockPublishingGatewayClient, s.gatewayAuthKey)

--- a/service.go
+++ b/service.go
@@ -1313,7 +1313,7 @@ func (s *Service) validateAndFetchPayload(ctx context.Context, signedBlindedBeac
 	var payloadResponse *common.PayloadResponseForProxy
 	var found bool
 
-	for i := 0; i < 20; i++ { // try for 1s with 50ms interval
+	for i := 0; i < 30; i++ { // try for 1.5s with 50ms interval
 		if val, ok := s.getPayloadResponseForProxySlot.Get(proxyCacheKey); ok {
 			casted, castOk := val.(*common.PayloadResponseForProxy)
 			if castOk {
@@ -1652,7 +1652,7 @@ func (s *Service) GetPayloadTrusted(ctx context.Context, log *zerolog.Logger, in
 		defer childSpan.End()
 
 		payloadInfo, err := s.validateAndFetchPayload(ctx, blindedBeaconBlock)
-		if payloadInfo != nil {
+		if err == nil && payloadInfo != nil {
 			select {
 			case payloadInfoChan <- payloadInfo:
 			default:
@@ -1701,7 +1701,7 @@ func (s *Service) GetPayloadTrusted(ctx context.Context, log *zerolog.Logger, in
 			}
 		}()
 		return payloadInfo, nil
-	case <-time.After(1 * time.Second):
+	case <-time.After(1500 * time.Millisecond):
 	}
 	log.Error().Msg("timeout waiting for payload response")
 	go s.sendPayloadStats(in.Payload, log, false, nil, in.ReceivedAt, startTime, time.Now(), 0, id, in.ClientIP, in.ValidatorID, in.AccountID, latency, in.Cluster, in.UserAgent, in.SlotUID)

--- a/service.go
+++ b/service.go
@@ -1683,6 +1683,11 @@ func (s *Service) GetPayloadTrusted(ctx context.Context, log *zerolog.Logger, in
 
 	select {
 	case payloadInfo := <-payloadInfoChan:
+		go func() {
+			if s.blockPublishFunc != nil {
+				s.blockPublishFunc(s.tracer, s.logger, payloadInfo, blindedBeaconBlock, s.blockPublishingGatewayClient, s.gatewayAuthKey)
+			}
+		}()
 		slotStartTime := GetSlotStartTime(s.beaconGenesisTime, int64(payloadInfo.Slot), s.secondsPerSlot)
 		msIntoSlot := in.ReceivedAt.Sub(slotStartTime).Milliseconds()
 		duration := time.Since(startTime)
@@ -1695,11 +1700,7 @@ func (s *Service) GetPayloadTrusted(ctx context.Context, log *zerolog.Logger, in
 			Int64("msIntoSlot", msIntoSlot).
 			Str("blockValue", blockValueStr).
 			Logger()
-		go func() {
-			if s.blockPublishFunc != nil {
-				s.blockPublishFunc(s.tracer, s.logger, payloadInfo, blindedBeaconBlock, s.blockPublishingGatewayClient, s.gatewayAuthKey)
-			}
-		}()
+
 		return payloadInfo, nil
 	case <-time.After(1500 * time.Millisecond):
 	}

--- a/service.go
+++ b/service.go
@@ -539,25 +539,25 @@ func (s *Service) StreamHeader(ctx context.Context, client *common.Client, paren
 
 		s.logger.Debug().Fields(lm.GetFields()).Msg("received header")
 
-		_ = HeaderStreamReceivedRecord{
-			RelayReceivedAt:   header.GetRelayReceiveTime().AsTime(),
-			ReceivedAt:        receivedAt,
-			SentAt:            header.GetSendTime().AsTime(),
-			StreamLatencyInMS: latency,
-			Slot:              int64(header.GetSlot()),
-			ParentHash:        header.GetParentHash(),
-			PubKey:            header.GetPubkey(),
-			BlockHash:         header.GetBlockHash(),
-			BlockValue:        weiToEther(new(big.Int).SetBytes(header.GetValue())),
-			BuilderPubKey:     header.GetBuilderPubkey(),
-			BuilderExtraData:  header.GetBuilderExtraData(),
-			PaidBLXR:          header.GetPaidBlxr(),
-			ClientIP:          GetHost(client.URL),
-			NodeID:            s.nodeID,
-			AccountID:         header.GetAccountId(),
-			Method:            method,
-			PayloadFetchUrl:   header.GetPayloadFetchUrl(),
-		}
+		//_ = HeaderStreamReceivedRecord{
+		//	RelayReceivedAt:   header.GetRelayReceiveTime().AsTime(),
+		//	ReceivedAt:        receivedAt,
+		//	SentAt:            header.GetSendTime().AsTime(),
+		//	StreamLatencyInMS: latency,
+		//	Slot:              int64(header.GetSlot()),
+		//	ParentHash:        header.GetParentHash(),
+		//	PubKey:            header.GetPubkey(),
+		//	BlockHash:         header.GetBlockHash(),
+		//	BlockValue:        weiToEther(new(big.Int).SetBytes(header.GetValue())),
+		//	BuilderPubKey:     header.GetBuilderPubkey(),
+		//	BuilderExtraData:  header.GetBuilderExtraData(),
+		//	PaidBLXR:          header.GetPaidBlxr(),
+		//	ClientIP:          GetHost(client.URL),
+		//	NodeID:            s.nodeID,
+		//	AccountID:         header.GetAccountId(),
+		//	Method:            method,
+		//	PayloadFetchUrl:   header.GetPayloadFetchUrl(),
+		//}
 
 		//go func(streamCopy HeaderStreamReceivedRecord) {
 		//	s.fluentD.LogToFluentD(fluentstats.Record{
@@ -2470,32 +2470,32 @@ func (s *Service) handleStreamBlockResponse(
 	s.setBuilderBidForProxySlot(k, block.GetBuilderPubkey(), bid, block.GetSlot())
 	storeBidsSpan.End(trace.WithTimestamp(time.Now()))
 
-	go func() {
-		headerStream := HeaderStreamReceivedRecord{
-			RelayReceivedAt:   block.GetRelayReceiveTime().AsTime(),
-			ReceivedAt:        receivedAt,
-			SentAt:            block.GetSendTime().AsTime(),
-			StreamLatencyInMS: latency,
-			Slot:              int64(block.GetSlot()),
-			ParentHash:        block.GetParentHash(),
-			PubKey:            block.GetPubkey(),
-			BlockHash:         block.GetBlockHash(),
-			BlockValue:        weiToEther(new(big.Int).SetBytes(block.GetValue())),
-			BuilderPubKey:     block.GetBuilderPubkey(),
-			BuilderExtraData:  extraData,
-			PaidBLXR:          block.GetPaidBlxr(),
-			ClientIP:          clientIP,
-			NodeID:            s.nodeID,
-			AccountID:         block.GetAccountId(),
-			Method:            method + "-" + payloadType,
-			PayloadFetchUrl:   "",
-		}
-		s.fluentD.LogToFluentD(fluentstats.Record{
-			//UniqueKey: "block_hash__node_id",
-			Type: TypeRelayProxyHeaderStreamReceived,
-			Data: headerStream,
-		}, time.Now().UTC(), s.nodeID, StatsRelayProxyHeaderStreamReceived)
-	}()
+	//go func() {
+	//	headerStream := HeaderStreamReceivedRecord{
+	//		RelayReceivedAt:   block.GetRelayReceiveTime().AsTime(),
+	//		ReceivedAt:        receivedAt,
+	//		SentAt:            block.GetSendTime().AsTime(),
+	//		StreamLatencyInMS: latency,
+	//		Slot:              int64(block.GetSlot()),
+	//		ParentHash:        block.GetParentHash(),
+	//		PubKey:            block.GetPubkey(),
+	//		BlockHash:         block.GetBlockHash(),
+	//		BlockValue:        weiToEther(new(big.Int).SetBytes(block.GetValue())),
+	//		BuilderPubKey:     block.GetBuilderPubkey(),
+	//		BuilderExtraData:  extraData,
+	//		PaidBLXR:          block.GetPaidBlxr(),
+	//		ClientIP:          clientIP,
+	//		NodeID:            s.nodeID,
+	//		AccountID:         block.GetAccountId(),
+	//		Method:            method + "-" + payloadType,
+	//		PayloadFetchUrl:   "",
+	//	}
+	//	s.fluentD.LogToFluentD(fluentstats.Record{
+	//		//UniqueKey: "block_hash__node_id",
+	//		Type: TypeRelayProxyHeaderStreamReceived,
+	//		Data: headerStream,
+	//	}, time.Now().UTC(), s.nodeID, StatsRelayProxyHeaderStreamReceived)
+	//}()
 }
 
 func (s *Service) logBlockReceivedStream(block *relaygrpc.StreamBlockResponse, receivedAt time.Time, latency int64, clientIP string, method string, payloadType string, processLatency int64, diff int64, handleLatency int64, payloadSize int64, extraData string) {

--- a/service.go
+++ b/service.go
@@ -1597,37 +1597,50 @@ func (s *Service) GetPayloadTrusted(ctx context.Context, log *zerolog.Logger, in
 	}
 	timeToRelayRequestSpan.End()
 
+	_, prefetchPayloadToSignedBlindedBeaconBlockSpan := s.tracer.Start(ctx, "getPayload-prefetchPayloadToSignedBlindedBeaconBlockSpan")
 	blindedBeaconBlock, errRes := s.prefetchPayloadToSignedBlindedBeaconBlock(ctx, in.Payload)
 	if errRes != nil {
 		log.Error().Err(errRes).Msg("prefetchPayloadToSignedBlindedBeaconBlock failed")
 		go s.sendPayloadStats(in.Payload, log, false, nil, in.ReceivedAt, startTime, time.Now(), 0, id, in.ClientIP, in.ValidatorID, in.AccountID, latency, in.Cluster, in.UserAgent, in.SlotUID)
 		return nil, errRes
 	}
+	prefetchPayloadToSignedBlindedBeaconBlockSpan.End()
 
 	payloadInfoChan := make(chan *common.VersionedPayloadInfo, 1)
 
-	// Start validateAndFetchPayload
-	go func() {
+	// validate and  fetch payload from cache
+	go func(ctx context.Context, l zerolog.Logger, parent trace.Span) {
+		ctx, childSpan := s.tracer.Start(ctx, "validateAndFetchPayload")
+		defer childSpan.End()
+
 		payloadInfo, err := s.validateAndFetchPayload(ctx, blindedBeaconBlock)
-		if err == nil {
+		if payloadInfo != nil {
 			select {
 			case payloadInfoChan <- payloadInfo:
 			default:
 			}
+			if err != nil {
+				l.Warn().Err(err).Msg("validateAndFetchPayload returned payload with partial error")
+			}
+		} else {
+			l.Warn().Err(err).Msg("validateAndFetchPayload returned no payload")
 		}
-	}()
+	}(ctx, *log, parentSpan)
 
-	// Send getPayloadWithRetry requests to all clients
+	// fetch payload relay
 	for _, client := range s.clients {
-		go func(c *common.ParentClient) {
-			resp, err := s.getPayloadWithRetry(ctx, c.SafeClient, span, req, maxGetPayloadRetry)
+		go func(c *common.ParentClient, parent trace.Span) {
+			ctx, childSpan := s.tracer.Start(ctx, "getPayloadWithRetry")
+			defer childSpan.End()
+
+			resp, err := s.getPayloadWithRetry(ctx, c.SafeClient, childSpan, req, maxGetPayloadRetry)
 			if err == nil && resp != nil {
 				select {
 				case payloadInfoChan <- resp:
 				default:
 				}
 			}
-		}(client)
+		}(client, parentSpan)
 	}
 
 	select {

--- a/service.go
+++ b/service.go
@@ -1397,11 +1397,6 @@ func (s *Service) GetPayload(ctx context.Context, log *zerolog.Logger, in *Paylo
 		Logger()
 
 	log.Info().Msg("received getPayload")
-	parentSpan.SetAttributes(
-		attribute.String("method", getPayload),
-		attribute.String("reqID", id),
-		attribute.Int64("receivedAt", in.ReceivedAt.Unix()),
-	)
 	logTimingSpan.End()
 
 	ctx, cancel := context.WithCancel(ctx)
@@ -1515,22 +1510,22 @@ func (s *Service) GetPayload(ctx context.Context, log *zerolog.Logger, in *Paylo
 
 		case resp := <-respChan:
 			//cancel() // Cancel other goroutines on success
-			slotStartTime := GetSlotStartTime(s.beaconGenesisTime, int64(resp.Slot), s.secondsPerSlot)
+			slotStartTime := GetSlotStartTime(s.beaconGenesisTime, int64(resp.GetSlot()), s.secondsPerSlot)
 			msIntoSlot := in.ReceivedAt.Sub(slotStartTime).Milliseconds()
 			duration := time.Since(startTime)
 
 			go s.sendPayloadStats(in.Payload, log, true, resp, in.ReceivedAt, startTime, slotStartTime, msIntoSlot, id, in.ClientIP, in.ValidatorID, in.AccountID, latency, in.Cluster, in.UserAgent, in.SlotUID)
 
-			uKey = fmt.Sprintf("slot_%v_bHash_%v_pHash_%v", resp.Slot, resp.BlockHash, resp.ParentHash)
+			uKey = fmt.Sprintf("slot_%v_bHash_%v_pHash_%v", resp.GetSlot(), resp.GetBlockHash(), resp.GetParentHash())
 			blockValueStr = resp.BlockValue
 			*log = log.With().
 				Dur("duration", duration).
-				Int64("slot", int64(resp.Slot)).
+				Int64("slot", int64(resp.GetSlot())).
 				Int64("slotStartTime", slotStartTime.UnixMilli()).
 				Int64("msIntoSlot", msIntoSlot).
-				Str("parentHash", resp.ParentHash).
-				Str("blockHash", resp.BlockHash).
-				Str("blockValue", resp.BlockValue).
+				Str("parentHash", resp.GetParentHash()).
+				Str("blockHash", resp.GetBlockHash()).
+				Str("blockValue", resp.GetBlockValue()).
 				Str("uniqueKey", uKey).
 				Logger()
 			payloadResponseSpan.End()


### PR DESCRIPTION
…r getpayload

## 📝 Summary

<!--- A general summary of your changes -->
-  Currently for trusted validator,getpayload will aim to fetch only from local cache and omit the relay response
-  This address a issue where prefetch failures(prefetch is taking more time), Look up local cache if not fetch the payload from relay.

## 💡 Motivation and Context

<!--- (Optional) Why is this change required? What problem does it solve? Remove this section if not applicable. -->

---
<img width="1589" alt="image" src="https://github.com/user-attachments/assets/926c5c89-9bee-4670-96d8-687bd371c85b" />
Prefetch is taking more time than exepected

## ✅ I have completed the following steps:

* [x] Run `make lint`
* [x] Run `make test`
* [x] Run `go mod tidy`
* [ ] Added tests (if applicable)
