### PR TITLE
Hotfix: respond status bad request instead of ok

### DIFF
--- a/getpayload.go
+++ b/getpayload.go
@@ -203,7 +203,7 @@ func (s *Service) GetPayload(ctx context.Context, log *zerolog.Logger, in *Paylo
 	}
 	log.Error().Msg("timeout waiting for payload response")
 	go s.sendPayloadStats(in.Payload, log, false, nil, in.ReceivedAt, startTime, time.Now(), 0, id, in.ClientIP, in.ValidatorID, in.AccountID, latency, in.Cluster, in.UserAgent, in.SlotUID)
-	return nil, toErrorResp(http.StatusOK, "pre fetch payload not available in cache after retries")
+	return nil, toErrorResp(http.StatusBadRequest, "no execution payload for this request")
 }
 
 type ErrorRespWithPayload struct {
@@ -507,6 +507,6 @@ func (s *Service) validateAndFetchPayload(ctx context.Context, signedBlindedBeac
 		ParentHash: parentHash.String(),
 		BlockHash:  blockHashString,
 		Pubkey:     pubkeyStr,
-	}, toErrorResp(http.StatusOK, "pre fetch payload not available in cache after retries")
+	}, toErrorResp(http.StatusBadRequest, "pre fetch payload not available in cache after retries")
 
 }


### PR DESCRIPTION
## 📝 Summary

<!--- A general summary of your changes -->
we are sending http success code for error cases. Thats the reason p2p were unable to parse it and crashing. The reason they p2p receive all block is that the they are currently unlicensed. Since we don’t stream all blocks to unlicensed validators, the rproxy does not have the winning payload available and therefore returns an 
[error.it](http://error.it/)  was supposed to fetch it from relay, for some reason it was not.

## 💡 Motivation and Context

<!--- (Optional) Why is this change required? What problem does it solve? Remove this section if not applicable. -->

---

## ✅ I have completed the following steps:

* [ ] Run `make lint`
* [ ] Run `make test`
* [ ] Run `go mod tidy`
* [ ] Added tests (if applicable)
