### PR TITLE
MEV-1751/Relay-Proxy-add-block-sequence-number-for-block-submissions

### DIFF
--- a/common/types.go
+++ b/common/types.go
@@ -341,17 +341,18 @@ func NewParentClient(safeUrl string, safeConn *grpc.ClientConn, fastUrl string, 
 }
 
 type Bid struct {
-	Value              []byte // block value
-	payload            []byte // blinded block
-	HeaderSubmissionV3 *optimisticv3.HeaderSubmissionV3
-	BlockHash          string
-	BuilderPubkey      string
-	BuilderExtraData   string
-	AccountID          string
-	Client             *ParentClient
-	PayloadFetchUrl    string
-	ReceivedAt         time.Time
-	AuthHeader         string
+	Value               []byte // block value
+	payload             []byte // blinded block
+	HeaderSubmissionV3  *optimisticv3.HeaderSubmissionV3
+	BlockHash           string
+	BuilderPubkey       string
+	BuilderExtraData    string
+	AccountID           string
+	Client              *ParentClient
+	PayloadFetchUrl     string
+	ReceivedAt          time.Time
+	AuthHeader          string
+	BlockSequenceNumber *uint64
 }
 
 func NewBid(Value []byte,
@@ -365,19 +366,21 @@ func NewBid(Value []byte,
 	payloadFetchUrl string,
 	receivedAt time.Time,
 	authHeader string,
+	blockSequenceNumber *uint64,
 ) *Bid {
 	return &Bid{
-		Value:              Value,
-		payload:            payload,
-		HeaderSubmissionV3: headerSubmissionV3,
-		BlockHash:          blockHash,
-		BuilderPubkey:      builderPubkey,
-		BuilderExtraData:   builderExtraData,
-		AccountID:          accountID,
-		Client:             client,
-		PayloadFetchUrl:    payloadFetchUrl,
-		ReceivedAt:         receivedAt,
-		AuthHeader:         authHeader,
+		Value:               Value,
+		payload:             payload,
+		HeaderSubmissionV3:  headerSubmissionV3,
+		BlockHash:           blockHash,
+		BuilderPubkey:       builderPubkey,
+		BuilderExtraData:    builderExtraData,
+		AccountID:           accountID,
+		Client:              client,
+		PayloadFetchUrl:     payloadFetchUrl,
+		ReceivedAt:          receivedAt,
+		AuthHeader:          authHeader,
+		BlockSequenceNumber: blockSequenceNumber,
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.24.2
 require (
 	github.com/attestantio/go-builder-client v0.6.3
 	github.com/attestantio/go-eth2-client v0.26.0
-	github.com/bloXroute-Labs/relay-grpc v0.0.62
+	github.com/bloXroute-Labs/relay-grpc v0.0.63
 	github.com/ethereum/go-ethereum v1.16.3
 	github.com/flashbots/go-boost-utils v1.9.0
 	github.com/fluent/fluent-logger-golang v1.9.0

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.24.2
 require (
 	github.com/attestantio/go-builder-client v0.6.3
 	github.com/attestantio/go-eth2-client v0.26.0
-	github.com/bloXroute-Labs/relay-grpc v0.0.59
+	github.com/bloXroute-Labs/relay-grpc v0.0.62
 	github.com/ethereum/go-ethereum v1.16.3
 	github.com/flashbots/go-boost-utils v1.9.0
 	github.com/fluent/fluent-logger-golang v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/attestantio/go-eth2-client v0.26.0 h1:oDWKvIUJfvr1EBi/w9L6mawYZHOCymj
 github.com/attestantio/go-eth2-client v0.26.0/go.mod h1:fvULSL9WtNskkOB4i+Yyr6BKpNHXvmpGZj9969fCrfY=
 github.com/bits-and-blooms/bitset v1.20.0 h1:2F+rfL86jE2d/bmw7OhqUg2Sj/1rURkBn3MdfoPyRVU=
 github.com/bits-and-blooms/bitset v1.20.0/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
-github.com/bloXroute-Labs/relay-grpc v0.0.62 h1:OHvw97tqpwsJLIdR5Cuf8qNiRQGujIATwlmvTQ/NOYU=
-github.com/bloXroute-Labs/relay-grpc v0.0.62/go.mod h1:z/QhiWStVWPJBaArHhzOCiMxzBbyvQB3L7P+KgmoNFI=
+github.com/bloXroute-Labs/relay-grpc v0.0.63 h1:wGJQCue1XGqTiGI+FIwOfMhKXrrw+W+In8/eL2NFOUs=
+github.com/bloXroute-Labs/relay-grpc v0.0.63/go.mod h1:z/QhiWStVWPJBaArHhzOCiMxzBbyvQB3L7P+KgmoNFI=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 h1:DDGfHa7BWjL4YnC6+E63dPcxHo2sUxDIu8g3QgEJdRY=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/attestantio/go-eth2-client v0.26.0 h1:oDWKvIUJfvr1EBi/w9L6mawYZHOCymj
 github.com/attestantio/go-eth2-client v0.26.0/go.mod h1:fvULSL9WtNskkOB4i+Yyr6BKpNHXvmpGZj9969fCrfY=
 github.com/bits-and-blooms/bitset v1.20.0 h1:2F+rfL86jE2d/bmw7OhqUg2Sj/1rURkBn3MdfoPyRVU=
 github.com/bits-and-blooms/bitset v1.20.0/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
-github.com/bloXroute-Labs/relay-grpc v0.0.59 h1:sNXeb3hxdQRb9Nhio6RAHXGVy3RYj9Z8IB11soRfW8U=
-github.com/bloXroute-Labs/relay-grpc v0.0.59/go.mod h1:z/QhiWStVWPJBaArHhzOCiMxzBbyvQB3L7P+KgmoNFI=
+github.com/bloXroute-Labs/relay-grpc v0.0.62 h1:OHvw97tqpwsJLIdR5Cuf8qNiRQGujIATwlmvTQ/NOYU=
+github.com/bloXroute-Labs/relay-grpc v0.0.62/go.mod h1:z/QhiWStVWPJBaArHhzOCiMxzBbyvQB3L7P+KgmoNFI=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 h1:DDGfHa7BWjL4YnC6+E63dPcxHo2sUxDIu8g3QgEJdRY=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=

--- a/server_test.go
+++ b/server_test.go
@@ -177,7 +177,7 @@ func TestServer_HandleRegistration(t *testing.T) {
 			go dataSvc.SetAccounts(context.Background())
 			h := server.Middleware(http.HandlerFunc(server.HandleRegistration))
 			h.ServeHTTP(rr, req)
-			assert.Equal(t, rr.Code, tc.expectedCode)
+			assert.Equal(t, tc.expectedCode, rr.Code)
 		})
 	}
 }
@@ -270,14 +270,14 @@ func TestServer_HandleGetHeader(t *testing.T) {
 			h := server.Middleware(http.HandlerFunc(server.HandleGetHeader))
 			h.ServeHTTP(rr, req)
 
-			assert.Equal(t, rr.Code, tc.expectedCode)
+			assert.Equal(t, tc.expectedCode, rr.Code)
 			if tc.expectedOutput != "" {
 				out := strings.TrimSpace(rr.Body.String())
 				out = strings.Trim(out, "\"")
-				assert.Equal(t, out, tc.expectedOutput)
+				assert.Equal(t, tc.expectedOutput, out)
 				return
 			}
-			assert.Equal(t, rr.Body.String(), tc.expectedOutput)
+			assert.Equal(t, tc.expectedOutput, rr.Body.String())
 		})
 	}
 }
@@ -324,12 +324,12 @@ func TestServer_HandleGetPayload(t *testing.T) {
 			h := server.Middleware(http.HandlerFunc(server.HandleGetPayload))
 			h.ServeHTTP(rr, req)
 
-			assert.Equal(t, rr.Code, tc.expectedCode)
+			assert.Equal(t, tc.expectedCode, rr.Code)
 			out := new(ErrorResp)
 			err = json.NewDecoder(rr.Body).Decode(out)
 			assert.NoError(t, err)
 			if tc.expectedError != "" {
-				assert.Equal(t, out.Message, tc.expectedError)
+				assert.Equal(t, tc.expectedError, out.Message)
 			}
 		})
 	}
@@ -407,17 +407,17 @@ func TestServer_HandleSetDelays(t *testing.T) {
 			svc := NewService(opts...)
 			server := &Server{svc: svc, logger: zerolog.Nop(), tracer: noop.NewTracerProvider().Tracer("test"), accountsLists: &AccountsLists{AccountIDToInfo: make(map[string]*AccountInfo), AccountNameToInfo: make(map[AccountName]*AccountInfo)}}
 			server.HandleSetDelays(rrPost, tc.reqPostFunc())
-			assert.Equal(t, rrPost.Code, tc.expectedPostCode)
+			assert.Equal(t, tc.expectedPostCode, rrPost.Code)
 
 			rrGet := httptest.NewRecorder()
 			server.HandleGetDelays(rrGet, tc.reqGetFunc())
-			assert.Equal(t, rrGet.Code, tc.expectedGetCode)
+			assert.Equal(t, tc.expectedGetCode, rrGet.Code)
 			out := make(map[string]DelaySettings)
 			err := json.NewDecoder(rrGet.Body).Decode(&out)
 			assert.NoError(t, err)
 			assert.Equal(t, tc.expectedGetOut, out)
 			//if tc.expectedError != "" {
-			//	assert.Equal(t, out.Message, tc.expectedError)
+			//	assert.Equal(t, tc.expectedError, out.Message)
 			//}
 		})
 	}

--- a/server_test.go
+++ b/server_test.go
@@ -117,6 +117,10 @@ func (m *MockService) GetPayload(ctx context.Context, log *zerolog.Logger, in *P
 	return nil, nil
 }
 
+func (m *MockService) GetPayloadV2(ctx context.Context, log *zerolog.Logger, in *PayloadRequestParams) *ErrorResp {
+	return nil
+}
+
 func TestServer_HandleRegistration(t *testing.T) {
 	testCases := map[string]struct {
 		requestBody  []byte

--- a/service.go
+++ b/service.go
@@ -597,7 +597,7 @@ func (s *Service) skipBidForOldBlockSequenceNumber(cacheKey string, builderPubke
 			Uint64("blockSequenceNumber", *blockSequenceNumber).
 			Str("cacheKey", cacheKey).
 			Str("builderPubkey", builderPubkey).
-			Msg("skipping bid for old block sequence")
+			Msg("skipping bid for old block sequence number")
 	}
 
 	return skipBid

--- a/service.go
+++ b/service.go
@@ -96,8 +96,8 @@ type Service struct {
 
 	clients                       []*common.ParentClient
 	streamingClients              []*common.ParentClient
-	streamingBlockClients         []*common.ParentClient
 	uniqueStreamingClients        []*common.ParentClient
+	streamingBlockClients         []*common.ParentClient
 	registrationClients           []*common.ParentClient
 	currentRegistrationRelayIndex int
 	registrationRelayMutex        sync.Mutex

--- a/service.go
+++ b/service.go
@@ -96,8 +96,8 @@ type Service struct {
 
 	clients                       []*common.ParentClient
 	streamingClients              []*common.ParentClient
-	uniqueStreamingClients        []*common.ParentClient
 	streamingBlockClients         []*common.ParentClient
+	uniqueStreamingClients        []*common.ParentClient
 	registrationClients           []*common.ParentClient
 	currentRegistrationRelayIndex int
 	registrationRelayMutex        sync.Mutex
@@ -344,6 +344,12 @@ func (s *Service) StreamHeader(ctx context.Context, client *common.Client, paren
 			continue
 		}
 
+		var blockSequenceNumber *uint64
+		headerBlockSequenceNumber := header.GetBlockSequenceNumber()
+		if headerBlockSequenceNumber != 0 {
+			blockSequenceNumber = &headerBlockSequenceNumber
+		}
+
 		// Process header
 		lm := logMetric.Copy()
 
@@ -351,19 +357,20 @@ func (s *Service) StreamHeader(ctx context.Context, client *common.Client, paren
 		uKey := fmt.Sprintf("slot_%v_bHash_%v_pHash_%v", header.GetSlot(), header.GetBlockHash(), header.GetParentHash())
 
 		lm.Fields(map[string]any{
-			"keyForCachingBids": k,
-			"slot":              header.GetSlot(),
-			"in.ParentHash":     header.GetParentHash(),
-			"blockHash":         header.GetBlockHash(),
-			"pubKey":            header.GetPubkey(),
-			"builderPubKey":     header.GetBuilderPubkey(),
-			"extraData":         header.GetBuilderExtraData(),
-			"traceID":           parentSpan.SpanContext().TraceID().String(),
-			"uniqueKey":         uKey,
-			"receivedAt":        receivedAt,
-			"paidBlxr":          header.GetPaidBlxr(),
-			"accountID":         header.GetAccountId(),
-			"payloadFetchUrl":   header.GetPayloadFetchUrl(),
+			"keyForCachingBids":   k,
+			"slot":                header.GetSlot(),
+			"in.ParentHash":       header.GetParentHash(),
+			"blockHash":           header.GetBlockHash(),
+			"pubKey":              header.GetPubkey(),
+			"builderPubKey":       header.GetBuilderPubkey(),
+			"extraData":           header.GetBuilderExtraData(),
+			"traceID":             parentSpan.SpanContext().TraceID().String(),
+			"uniqueKey":           uKey,
+			"receivedAt":          receivedAt,
+			"paidBlxr":            header.GetPaidBlxr(),
+			"accountID":           header.GetAccountId(),
+			"payloadFetchUrl":     header.GetPayloadFetchUrl(),
+			"blockSequenceNumber": header.GetBlockSequenceNumber(),
 		})
 
 		var (
@@ -450,6 +457,7 @@ func (s *Service) StreamHeader(ctx context.Context, client *common.Client, paren
 			header.GetPayloadFetchUrl(),
 			header.GetRelayReceiveTime().AsTime(),
 			"",
+			blockSequenceNumber,
 		)
 		s.setBuilderBidForProxySlot(k, header.GetBuilderPubkey(), bid, header.GetSlot())
 		storeBidsSpan.SetAttributes(
@@ -623,486 +631,6 @@ func (s *Service) EmitSlotStats(ctx context.Context) {
 			return
 		}
 	}
-}
-
-func (s *Service) StartStreamBlocks(ctx context.Context, wg *sync.WaitGroup) {
-	for _, client := range s.streamingBlockClients {
-		wg.Add(1)
-		go func(_ctx context.Context, c *common.ParentClient) {
-			defer wg.Done()
-			s.handleBlockStream(_ctx, c)
-		}(ctx, client)
-	}
-	go s.handleForwardedBlockResponse()
-	wg.Wait()
-}
-
-func (s *Service) handleBlockStream(ctx context.Context, client *common.ParentClient) {
-	parentSpan := trace.SpanFromContext(ctx)
-	ctx = trace.ContextWithSpan(context.Background(), parentSpan)
-	_, span := s.tracer.Start(ctx, "handleBlockStream-streamBlock")
-	defer span.End(trace.WithTimestamp(time.Now().UTC()))
-
-	traceID := parentSpan.SpanContext().TraceID().String()
-
-	span.SetAttributes(
-		attribute.String("method", "streamBlock"),
-		attribute.String("url", client.SafeClient.URL),
-		attribute.String("traceID", traceID),
-	)
-
-	var lastConnectTime time.Time
-
-	for {
-		select {
-		case <-ctx.Done():
-			s.logger.Warn().
-				Str("traceID", traceID).
-				Msg("stream block context cancelled")
-			return
-		default:
-			active, safe := client.GetActiveClient(lastConnectTime)
-			if safe {
-				s.logger.Warn().Str("method", "streamBlock").Str("fastURL", client.FastClient.URL).Str("safeURL", client.SafeClient.URL).Msg("Fallback to safe IP used")
-			}
-			lastConnectTime = time.Now()
-			if _, err := s.StreamBlock(ctx, active); err != nil {
-				s.logger.Warn().
-					Str("url", active.URL).
-					Str("traceID", traceID).
-					Err(err).
-					Msg("failed to stream block. Sleeping and then reconnecting")
-
-				span.SetAttributes(
-					attribute.Int64("sleepingFor", reconnectTime),
-					attribute.String("error", err.Error()),
-				)
-			} else {
-				s.logger.Warn().
-					Str("url", active.URL).
-					Str("traceID", traceID).
-					Msg("stream block stopped. Sleeping and then reconnecting")
-
-				span.SetAttributes(
-					attribute.Int64("sleepingFor", reconnectTime),
-					attribute.String("error", "stream header stopped."),
-				)
-			}
-			time.Sleep(reconnectTime * time.Millisecond)
-		}
-	}
-}
-
-func (s *Service) StreamBlock(ctx context.Context, client *common.Client) (*relaygrpc.StreamBlockResponse, error) {
-	parentSpan := trace.SpanFromContext(ctx)
-	method := "streamBlock"
-	ctx = trace.ContextWithSpan(context.Background(), parentSpan)
-	ctx = metadata.AppendToOutgoingContext(ctx, "authorization", s.authKey)
-	_, port, err := net.SplitHostPort(s.listenAddress)
-	if err != nil {
-		s.logger.Warn().Err(err).Msg("failed to split host port")
-		return nil, err
-	}
-	ctx = metadata.AppendToOutgoingContext(ctx, "listenAddress", port)
-	ctx = metadata.AppendToOutgoingContext(ctx, "grpcListenAddress", s.GrpcListenAddress)
-	streamBlockCtx, span := s.tracer.Start(ctx, "streamBlock-start")
-	defer span.End(trace.WithTimestamp(time.Now().UTC()))
-	id := uuid.NewString()
-	client.NodeID = fmt.Sprintf("%v-%v-%v-%v", s.nodeID, client.URL, id, time.Now().UTC().Format("15:04:05.999999999"))
-	stream, err := client.StreamBlock(ctx, &relaygrpc.StreamBlockRequest{
-		ReqId:       id,
-		NodeId:      client.NodeID,
-		Version:     s.version,
-		SecretToken: s.secretToken,
-	})
-	logMetric := NewLogMetric(
-		map[string]any{
-			"method": method,
-			"nodeID": client.NodeID,
-			"reqID":  id,
-			"url":    client.URL,
-		},
-	)
-	span.SetAttributes(
-		attribute.String("method", method),
-		attribute.String("nodeID", client.NodeID),
-		attribute.String("url", client.URL),
-		attribute.String("reqID", id),
-	)
-
-	s.logger.Info().Fields(logMetric.GetFields()).Msg("streaming blocks")
-	if err != nil {
-		logMetric.Error(err)
-		s.logger.Warn().Fields(logMetric.GetFields()).Msg("failed to stream block")
-		span.SetStatus(otelcodes.Error, err.Error())
-		return nil, err
-	}
-	done := make(chan struct{})
-	var once sync.Once
-	closeDone := func() {
-		once.Do(func() {
-			s.logger.Info().Msg("calling close done once")
-			close(done)
-		})
-	}
-	logMetricCopy := logMetric.Copy()
-	go func(lm *LogMetric) {
-		select {
-		case <-stream.Context().Done():
-			lm.Error(stream.Context().Err())
-			s.logger.Warn().Fields(lm.GetFields()).Msg("stream context cancelled, closing connection")
-			closeDone()
-		case <-ctx.Done():
-			logMetric.Error(ctx.Err())
-			s.logger.Warn().Fields(lm.GetFields()).Msg("context cancelled, closing connection")
-			closeDone()
-		}
-	}(logMetricCopy)
-
-	_, streamReceiveSpan := s.tracer.Start(streamBlockCtx, "StreamBlock-streamReceive")
-	clientIP := GetHost(client.URL)
-	for {
-		select {
-		case <-done:
-			return nil, nil
-		default:
-		}
-		block, err := stream.Recv()
-		receivedAt := time.Now().UTC()
-		if err == io.EOF {
-			s.logger.Warn().Err(err).Fields(logMetric.GetFields()).Msg("stream received EOF")
-			streamReceiveSpan.SetStatus(otelcodes.Error, err.Error())
-			closeDone()
-			break
-		}
-		_s, ok := status.FromError(err)
-		if !ok {
-			s.logger.Warn().Err(err).Fields(logMetric.GetFields()).Msg("invalid grpc error status")
-			streamReceiveSpan.SetStatus(otelcodes.Error, "invalid grpc error status")
-			continue
-		}
-
-		if _s.Code() == codes.Canceled {
-			logMetric.Error(err)
-			s.logger.Warn().Err(err).Fields(logMetric.GetFields()).Msg("received cancellation signal, shutting down")
-			// mark as canceled to stop the upstream retry loop
-			streamReceiveSpan.SetStatus(otelcodes.Error, "received cancellation signal")
-			closeDone()
-			break
-		}
-
-		if _s.Code() != codes.OK {
-			s.logger.Warn().Err(_s.Err()).Str("code", _s.Code().String()).Fields(logMetric.GetFields()).Msg("server unavailable,try reconnecting")
-			streamReceiveSpan.SetStatus(otelcodes.Error, "server unavailable,try reconnecting")
-			closeDone()
-			break
-		}
-		if err != nil {
-			s.logger.Warn().Err(err).Fields(logMetric.GetFields()).Msg("failed to receive stream, disconnecting the stream")
-			streamReceiveSpan.SetStatus(otelcodes.Error, err.Error())
-			closeDone()
-			break
-		}
-		// Added empty streaming as a temporary workaround to maintain streaming alive
-		// TODO: this need to be handled by adding settings for keep alive params on both server and client
-		if block.GetBlockHash() == "" {
-			s.logger.Warn().Fields(logMetric.GetFields()).Msg("received empty stream")
-			continue
-		}
-		latency := receivedAt.Sub(block.GetSendTime().AsTime()).Milliseconds()
-		processTime := time.Since(receivedAt).Milliseconds()
-		go s.handleStreamBlockResponse(streamBlockCtx, block, logMetric, receivedAt, latency, parentSpan.SpanContext().TraceID().String(), method, clientIP, processTime)
-	}
-	<-done
-	streamReceiveSpan.End(trace.WithTimestamp(time.Now()))
-
-	s.logger.Warn().Fields(logMetric.GetFields()).Msg("closing connection")
-	return nil, nil
-}
-
-func (s *Service) handleForwardedBlockResponse() {
-	s.logger.Info().Msg("start handling forwarded block response")
-	for forwardedBlockInfo := range *s.forwardedBlockCh {
-		// s.logger.Info().Msg("received forwarded block from channel")
-
-		lm := NewLogMetric(
-			map[string]any{
-				"method": forwardedBlockInfo.Method,
-			},
-		)
-		if forwardedBlockInfo.Block == nil || forwardedBlockInfo.Block.GetBlockHash() == "" {
-			s.logger.Warn().Fields(lm.GetFields()).Msg("received empty forwarded block")
-			continue
-		}
-		go s.handleStreamBlockResponse(
-			forwardedBlockInfo.Context,
-			forwardedBlockInfo.Block,
-			lm,
-			forwardedBlockInfo.ReceivedAt,
-			forwardedBlockInfo.Latency,
-			forwardedBlockInfo.TraceID,
-			forwardedBlockInfo.Method,
-			forwardedBlockInfo.ClientIP,
-			forwardedBlockInfo.ProcessTime,
-		)
-	}
-	s.logger.Info().Msg("stop handling forwarded block response")
-}
-
-func (s *Service) handleStreamBlockResponse(
-	ctx context.Context,
-	block *relaygrpc.StreamBlockResponse,
-	logMetric *LogMetric,
-	receivedAt time.Time,
-	latency int64,
-	traceId string,
-	method string,
-	clientIP string,
-	processTime int64,
-) {
-	// check if the block hash has already been received
-	handleStart := time.Now().UTC()
-	lm := logMetric.Copy()
-
-	k := s.keyForCachingBids(block.GetSlot(), block.GetParentHash(), block.GetPubkey())
-	uKey := fmt.Sprintf("slot_%v_bHash_%v_pHash_%v", block.GetSlot(), block.GetBlockHash(), block.GetParentHash())
-	payloadSize := len(block.GetPayload())
-	payloadType := ""
-	extraData := block.GetBuilderExtraData()
-
-	lm.Fields(map[string]any{
-		"keyForCachingBids": k,
-		"slot":              block.GetSlot(),
-		"parentHash":        block.GetParentHash(),
-		"blockHash":         block.GetBlockHash(),
-		"pubKey":            block.GetPubkey(),
-		"builderPubKey":     block.GetBuilderPubkey(),
-		"extraData":         extraData,
-		"traceID":           traceId,
-		"uniqueKey":         uKey,
-		"receivedAt":        receivedAt,
-		"paidBlxr":          block.GetPaidBlxr(),
-		"accountID":         block.GetAccountId(),
-		"streamLatencyInMs": latency,
-		"processLatency":    processTime,
-		"httpPayloadSize":   int64(payloadSize),
-	})
-
-	spanCtx, span := s.tracer.Start(ctx, "handleStreamBlockResponse")
-	diff := int64(0)
-	defer func() {
-		handleTime := time.Since(handleStart).Milliseconds()
-		span.SetAttributes(
-			attribute.String("keyForCachingBids", k),
-			attribute.Int64("slot", int64(block.GetSlot())),
-			attribute.String("parentHash", block.GetParentHash()),
-			attribute.String("blockHash", block.GetBlockHash()),
-			attribute.String("pubKey", block.GetPubkey()),
-			attribute.String("builderPubKey", block.GetBuilderPubkey()),
-			attribute.String("extraData", extraData),
-			attribute.String("traceID", traceId),
-			attribute.String("blockHash", block.GetBlockHash()),
-		)
-		span.End()
-		go s.logBlockReceivedStream(
-			block,
-			receivedAt,
-			latency,
-			clientIP,
-			method,
-			payloadType,
-			processTime,
-			diff,
-			handleTime,
-			int64(payloadSize),
-			extraData,
-		)
-	}()
-
-	if val, exist := s.builderExistingBlockHash.Get(block.GetBlockHash()); exist {
-		var addedAt int64
-		var source string
-		if v, ok := val.(common.DuplicateBlock); ok {
-			addedAt = v.Time
-			source = v.Source
-		}
-		duplicateReceiveTime := time.Now().UTC().UnixMilli()
-		diff := duplicateReceiveTime - addedAt
-		lm.Fields(map[string]any{
-			"addedAt":              addedAt,
-			"duplicateReceiveTime": duplicateReceiveTime,
-			"diff":                 diff,
-			"source":               source,
-		})
-		span.SetAttributes(
-			attribute.Int64("diff", diff),
-			attribute.Int64("addedAt", addedAt),
-			attribute.String("source", source),
-		)
-		s.logger.Warn().Fields(lm.GetFields()).Msg("block hash already exist")
-		return
-	}
-
-	grpcPayload := block.GetGrpcPayload()
-	httpPayload := block.GetPayload()
-	submitBlockRequest := new(common.VersionedSubmitBlockRequest)
-	_, unmarshalSpan := s.tracer.Start(spanCtx, "handleStreamBlockResponse-unmarshal")
-	if grpcPayload != nil {
-		submission, err := relaygrpc.ProtoRequestToVersionedRequest(grpcPayload)
-		if err != nil {
-			s.logger.Error().Err(err).Msg("could not convert block to versioned block")
-			unmarshalSpan.End()
-			return
-		}
-		submitBlockRequest = &common.VersionedSubmitBlockRequest{VersionedSubmitBlockRequest: *submission}
-		payloadType = "grpc"
-	} else if httpPayload != nil {
-		payloadType = "json"
-		if err := submitBlockRequest.UnmarshalJSON(httpPayload); err != nil {
-			if err := submitBlockRequest.UnmarshalSSZ(httpPayload); err != nil {
-				s.logger.Error().Err(err).Msg("could not decode ssz http payload")
-				unmarshalSpan.End()
-				return
-			}
-			payloadType = "ssz"
-		}
-	} else {
-		s.logger.Error().Msg("empty payload")
-		return
-	}
-	unmarshalSpan.End()
-
-	lm.Fields(map[string]any{
-		"blockValue":     new(big.Int).SetBytes(block.GetValue()).String(),
-		"relayReceiveAt": block.GetRelayReceiveTime().AsTime(),
-		"streamSentAt":   block.GetSendTime().AsTime(),
-		"payloadType":    payloadType,
-	})
-	span.SetAttributes(
-		attribute.String("blockValue", new(big.Int).SetBytes(block.GetValue()).String()),
-		attribute.String("relayReceiveAt", block.GetRelayReceiveTime().AsTime().String()),
-		attribute.String("streamSentAt", block.GetSendTime().AsTime().String()),
-		attribute.String("payloadType", payloadType),
-	)
-
-	_, signSpan := s.tracer.Start(spanCtx, "handleStreamBlockResponse-sign")
-	headerSubmissionV3, err := common.BuildHeaderSubmissionV3(submitBlockRequest)
-	if err != nil {
-		s.logger.Error().Err(err).Msg("failed to build header submission")
-		signSpan.End()
-		return
-	}
-	relayProxyGetHeaderResponse, err := common.BuildGetHeaderResponseAndSign(headerSubmissionV3, s.secretKey, &s.publicKey, s.builderSigningDomain)
-	if err != nil {
-		s.logger.Error().Err(err).Msg("failed to sign header")
-		signSpan.End()
-		return
-	}
-	signSpan.End()
-
-	wrapped := &common.VersionedSignedBuilderBid{VersionedSignedBuilderBid: *relayProxyGetHeaderResponse}
-	_, marshalSpan := s.tracer.Start(spanCtx, "handleStreamBlockResponse-marshal")
-	relayProxyBidBytes, err := json.Marshal(wrapped)
-	if err != nil {
-		s.logger.Error().Err(err).Msg("failed to marshal header")
-		marshalSpan.End()
-		return
-	}
-	marshalSpan.End()
-
-	if extraData == "" {
-		extraDataBytes, err := wrapped.ExtraData()
-		if err != nil {
-			s.logger.Error().Err(err).Msg("failed to get extra data")
-		} else {
-			extraData = common.DecodeExtraData(extraDataBytes)
-		}
-	}
-
-	bid := common.NewBid(
-		block.GetValue(),
-		relayProxyBidBytes,
-		headerSubmissionV3,
-		block.GetBlockHash(),
-		block.GetBuilderPubkey(),
-		extraData,
-		block.GetAccountId(),
-		nil,
-		"",
-		block.RelayReceiveTime.AsTime(),
-		"",
-	)
-
-	// update block hash map if not seen already
-	s.builderExistingBlockHash.Set(block.GetBlockHash(), common.DuplicateBlock{
-		Time:   time.Now().UTC().UnixMilli(),
-		Source: "proxy-block-" + clientIP,
-	}, cache.DefaultExpiration)
-
-	s.logger.Info().Fields(lm.GetFields()).Msg("received streamed block")
-
-	_, storeBidsSpan := s.tracer.Start(spanCtx, "StreamHeader-storeBids")
-	s.setBuilderBidForProxySlot(k, block.GetBuilderPubkey(), bid, block.GetSlot())
-	storeBidsSpan.End(trace.WithTimestamp(time.Now()))
-
-	//go func() {
-	//	headerStream := HeaderStreamReceivedRecord{
-	//		RelayReceivedAt:   block.GetRelayReceiveTime().AsTime(),
-	//		ReceivedAt:        receivedAt,
-	//		SentAt:            block.GetSendTime().AsTime(),
-	//		StreamLatencyInMS: latency,
-	//		Slot:              int64(block.GetSlot()),
-	//		ParentHash:        block.GetParentHash(),
-	//		PubKey:            block.GetPubkey(),
-	//		BlockHash:         block.GetBlockHash(),
-	//		BlockValue:        weiToEther(new(big.Int).SetBytes(block.GetValue())),
-	//		BuilderPubKey:     block.GetBuilderPubkey(),
-	//		BuilderExtraData:  extraData,
-	//		PaidBLXR:          block.GetPaidBlxr(),
-	//		ClientIP:          clientIP,
-	//		NodeID:            s.nodeID,
-	//		AccountID:         block.GetAccountId(),
-	//		Method:            method + "-" + payloadType,
-	//		PayloadFetchUrl:   "",
-	//	}
-	//	s.fluentD.LogToFluentD(fluentstats.Record{
-	//		//UniqueKey: "block_hash__node_id",
-	//		Type: TypeRelayProxyHeaderStreamReceived,
-	//		Data: headerStream,
-	//	}, time.Now().UTC(), s.nodeID, StatsRelayProxyHeaderStreamReceived)
-	//}()
-}
-
-func (s *Service) logBlockReceivedStream(block *relaygrpc.StreamBlockResponse, receivedAt time.Time, latency int64, clientIP string, method string, payloadType string, processLatency int64, diff int64, handleLatency int64, payloadSize int64, extraData string) {
-	// log block received stream
-	blockStream := BlockStreamReceivedRecord{
-		RelayReceivedAt:   block.GetRelayReceiveTime().AsTime(),
-		ReceivedAt:        receivedAt,
-		SentAt:            block.GetSendTime().AsTime(),
-		StreamLatencyInMS: latency,
-		Slot:              int64(block.GetSlot()),
-		ParentHash:        block.GetParentHash(),
-		PubKey:            block.GetPubkey(),
-		BlockHash:         block.GetBlockHash(),
-		BlockValue:        weiToEther(new(big.Int).SetBytes(block.GetValue())),
-		BuilderPubKey:     block.GetBuilderPubkey(),
-		BuilderExtraData:  extraData,
-		PaidBLXR:          block.GetPaidBlxr(),
-		ClientIP:          clientIP,
-		NodeID:            s.nodeID,
-		AccountID:         block.GetAccountId(),
-		Method:            method + "-" + payloadType,
-		ProcessLatency:    processLatency,
-		Diff:              diff,
-		HandleLatency:     handleLatency,
-		PayloadSize:       payloadSize,
-	}
-	s.fluentD.LogToFluentD(fluentstats.Record{
-		//UniqueKey: "block_hash__node_id",
-		Type: TypeRelayProxyBlockStreamReceived,
-		Data: blockStream,
-	}, time.Now().UTC(), s.nodeID, StatsRelayProxyBlockStreamReceived)
-
 }
 
 func isVouch(userAgent string) bool {

--- a/service.go
+++ b/service.go
@@ -353,11 +353,11 @@ func (s *Service) StreamHeader(ctx context.Context, client *common.Client, paren
 		// Process header
 		lm := logMetric.Copy()
 
-		k := s.keyForCachingBids(header.GetSlot(), header.GetParentHash(), header.GetPubkey())
-		uKey := fmt.Sprintf("slot_%v_bHash_%v_pHash_%v", header.GetSlot(), header.GetBlockHash(), header.GetParentHash())
+		keyForCachingBids := s.keyForCachingBids(header.GetSlot(), header.GetParentHash(), header.GetPubkey())
+		uniqueKey := fmt.Sprintf("slot_%v_bHash_%v_pHash_%v", header.GetSlot(), header.GetBlockHash(), header.GetParentHash())
 
 		lm.Fields(map[string]any{
-			"keyForCachingBids":   k,
+			"keyForCachingBids":   keyForCachingBids,
 			"slot":                header.GetSlot(),
 			"in.ParentHash":       header.GetParentHash(),
 			"blockHash":           header.GetBlockHash(),
@@ -365,13 +365,17 @@ func (s *Service) StreamHeader(ctx context.Context, client *common.Client, paren
 			"builderPubKey":       header.GetBuilderPubkey(),
 			"extraData":           header.GetBuilderExtraData(),
 			"traceID":             parentSpan.SpanContext().TraceID().String(),
-			"uniqueKey":           uKey,
+			"uniqueKey":           uniqueKey,
 			"receivedAt":          receivedAt,
 			"paidBlxr":            header.GetPaidBlxr(),
 			"accountID":           header.GetAccountId(),
 			"payloadFetchUrl":     header.GetPayloadFetchUrl(),
 			"blockSequenceNumber": header.GetBlockSequenceNumber(),
 		})
+
+		if s.skipBidForOldBlockSequenceNumber(keyForCachingBids, header.GetBuilderPubkey(), blockSequenceNumber) {
+			continue
+		}
 
 		var (
 			duplicateReceiveTime int64
@@ -392,9 +396,10 @@ func (s *Service) StreamHeader(ctx context.Context, client *common.Client, paren
 				"source":     source,
 			})
 
-			s.logger.Debug().Fields(lm.GetFields()).Msg("block hash already exist")
+			s.logger.Debug().Fields(lm.GetFields()).Msg("block hash already exists")
 			continue
 		}
+
 		// update block hash map if not seen already
 		s.builderExistingBlockHash.Set(header.GetBlockHash(), common.DuplicateBlock{
 			Time:   time.Now().UTC().UnixMilli(),
@@ -459,7 +464,7 @@ func (s *Service) StreamHeader(ctx context.Context, client *common.Client, paren
 			"",
 			blockSequenceNumber,
 		)
-		s.setBuilderBidForProxySlot(k, header.GetBuilderPubkey(), bid, header.GetSlot())
+		s.setBuilderBidForProxySlot(keyForCachingBids, header.GetBuilderPubkey(), bid, header.GetSlot())
 		storeBidsSpan.SetAttributes(
 			attribute.String("method", method),
 			attribute.String("nodeID", client.NodeID),
@@ -470,7 +475,7 @@ func (s *Service) StreamHeader(ctx context.Context, client *common.Client, paren
 			attribute.String("streamSentAt", header.GetSendTime().AsTime().String()),
 			attribute.Int64("streamLatencyInMs", latency),
 
-			attribute.String("keyForCachingBids", k),
+			attribute.String("keyForCachingBids", keyForCachingBids),
 			attribute.Int64("slot", int64(header.GetSlot())),
 			attribute.String("in.ParentHash", header.GetParentHash()),
 			attribute.String("blockHash", header.GetBlockHash()),
@@ -478,7 +483,7 @@ func (s *Service) StreamHeader(ctx context.Context, client *common.Client, paren
 			attribute.String("builderPubKey", header.GetBuilderPubkey()),
 			attribute.String("extraData", header.GetBuilderExtraData()),
 			attribute.String("traceID", parentSpan.SpanContext().TraceID().String()),
-			attribute.String("uniqueKey", uKey),
+			attribute.String("uniqueKey", uniqueKey),
 			attribute.String("receivedAt", receivedAt.String()),
 			attribute.Bool("paidBlxr", header.GetPaidBlxr()),
 			attribute.String("accountID", header.GetAccountId()),
@@ -539,7 +544,6 @@ func (s *Service) GetTopBuilderBid(cacheKey string) (*common.Bid, *common.Bid, e
 }
 
 func (s *Service) setBuilderBidForProxySlot(cacheKey string, builderPubkey string, bid *common.Bid, slot uint64) {
-
 	var builderBidsMap *SyncMap[string, *common.Bid]
 
 	// if the cache key does not exist, create a new syncmap and store it in the cache
@@ -571,7 +575,6 @@ func (s *Service) setBuilderBidForProxySlot(cacheKey string, builderPubkey strin
 	builderBidsMap.Store(builderPubkey, bid)
 }
 
-// This is only used for testing
 func (s *Service) getBuilderBidForSlot(cacheKey string, builderPubkey string) (*common.Bid, bool) {
 	if entry, bidsMapFound := s.builderBidsForProxySlot.Get(cacheKey); bidsMapFound {
 		builderBidsMap := entry.(*SyncMap[string, *common.Bid])
@@ -579,6 +582,25 @@ func (s *Service) getBuilderBidForSlot(cacheKey string, builderPubkey string) (*
 		return builderBid, found
 	}
 	return nil, false
+}
+
+func (s *Service) skipBidForOldBlockSequenceNumber(cacheKey string, builderPubkey string, blockSequenceNumber *uint64) bool {
+	existingBid, found := s.getBuilderBidForSlot(cacheKey, builderPubkey)
+	if !found || existingBid.BlockSequenceNumber == nil || blockSequenceNumber == nil {
+		return false
+	}
+
+	skipBid := *blockSequenceNumber <= *existingBid.BlockSequenceNumber
+	if skipBid {
+		s.logger.Warn().
+			Uint64("existingBlockSequenceNumber", *existingBid.BlockSequenceNumber).
+			Uint64("blockSequenceNumber", *blockSequenceNumber).
+			Str("cacheKey", cacheKey).
+			Str("builderPubkey", builderPubkey).
+			Msg("skipping bid for old block sequence")
+	}
+
+	return skipBid
 }
 
 func (s *Service) EmitSlotStats(ctx context.Context) {

--- a/service_test.go
+++ b/service_test.go
@@ -302,6 +302,7 @@ func TestBlockCancellation(t *testing.T) {
 		"",
 		time.Now(),
 		"",
+		nil,
 	)
 	bidsMap.Store(testBuilderPubkey1, lowBid)
 
@@ -318,6 +319,7 @@ func TestBlockCancellation(t *testing.T) {
 		"",
 		time.Now(),
 		"",
+		nil,
 	)
 	bidsMap.Store(testBuilderPubkey2, highBid)
 
@@ -334,6 +336,7 @@ func TestBlockCancellation(t *testing.T) {
 		"",
 		time.Now(),
 		"",
+		nil,
 	)
 	bidsMap.Store(testBuilderPubkey3, mediumBid)
 
@@ -378,6 +381,7 @@ func TestBlockCancellationForSamePubKey(t *testing.T) {
 		"",
 		time.Now(),
 		"",
+		nil,
 	)
 	bidsMap.Store(testBuilderPubkey1, lowBid)
 
@@ -394,6 +398,7 @@ func TestBlockCancellationForSamePubKey(t *testing.T) {
 		"",
 		time.Now(),
 		"",
+		nil,
 	)
 	bidsMap.Store(testBuilderPubkey1, highBid)
 
@@ -410,6 +415,7 @@ func TestBlockCancellationForSamePubKey(t *testing.T) {
 		"",
 		time.Now(),
 		"",
+		nil,
 	)
 	bidsMap.Store(testBuilderPubkey1, mediumBid)
 
@@ -427,6 +433,7 @@ func TestBlockCancellationForSamePubKey(t *testing.T) {
 		"",
 		time.Now(),
 		"",
+		nil,
 	)
 	bidsMap.Store(testBuilderPubkey2, lowBid1)
 
@@ -443,6 +450,7 @@ func TestBlockCancellationForSamePubKey(t *testing.T) {
 		"",
 		time.Now(),
 		"",
+		nil,
 	)
 	bidsMap.Store(testBuilderPubkey2, mediumBid1)
 
@@ -459,6 +467,7 @@ func TestBlockCancellationForSamePubKey(t *testing.T) {
 		"",
 		time.Now(),
 		"",
+		nil,
 	)
 	bidsMap.Store(testBuilderPubkey2, highBid1)
 
@@ -476,6 +485,7 @@ func TestBlockCancellationForSamePubKey(t *testing.T) {
 		"",
 		time.Now(),
 		"",
+		nil,
 	)
 	bidsMap.Store(testBuilderPubkey3, mediumBid2)
 
@@ -492,6 +502,7 @@ func TestBlockCancellationForSamePubKey(t *testing.T) {
 		"",
 		time.Now(),
 		"",
+		nil,
 	)
 	bidsMap.Store(testBuilderPubkey3, highBid2)
 
@@ -508,6 +519,7 @@ func TestBlockCancellationForSamePubKey(t *testing.T) {
 		"",
 		time.Now(),
 		"",
+		nil,
 	)
 	bidsMap.Store(testBuilderPubkey3, lowBid2)
 


### PR DESCRIPTION
-Adds a check for block sequence number to skip processing of old/out of order streamed headers.

-The original sequence number itself is set by builders on their block submissions, either by using the `X-Sequence` header or adding the proper field to a GRPC submission.

## ✅ I have completed the following steps:

* [x] Run `make lint`
* [ ] Run `make test`
* [x] Run `go mod tidy`
* [ ] Added tests (if applicable)
