### PR TITLE
handle error resp nil check properly

### DIFF
--- a/server.go
+++ b/server.go
@@ -484,10 +484,7 @@ func (s *Server) HandleRegistration(w http.ResponseWriter, r *http.Request) {
 			100)
 	}()
 
-	parentSpan := trace.SpanFromContext(r.Context())
-	parentSpanCtx := trace.ContextWithSpan(context.Background(), parentSpan)
-	handleRegistrationCtx, handleRegistrationSpan := s.tracer.Start(parentSpanCtx, "handleRegistration-start")
-	defer parentSpan.End()
+	handleRegistrationCtx, handleRegistrationSpan := s.tracer.Start(r.Context(), "handleRegistration-start")
 	defer handleRegistrationSpan.End()
 
 	receivedAt := time.Now().UTC()
@@ -609,9 +606,7 @@ func (s *Server) HandleGetHeader(w http.ResponseWriter, r *http.Request) {
 	start := time.Now().UTC()
 	success := false
 
-	parentSpan := trace.SpanFromContext(r.Context())
-	parentSpanCtx := trace.ContextWithSpan(context.Background(), parentSpan)
-	handleGetHeaderCtx, span := s.tracer.Start(parentSpanCtx, "handleGetHeader-start")
+	handleGetHeaderCtx, span := s.tracer.Start(r.Context(), "handleGetHeader-start")
 
 	receivedAt := time.Now().UTC()
 	slot := chi.URLParam(r, "slot")
@@ -672,7 +667,6 @@ func (s *Server) HandleGetHeader(w http.ResponseWriter, r *http.Request) {
 				attribute.String("blockHash", onHeaderDeliveredParams.BlockHash),
 			)
 		}
-		parentSpan.End()
 		span.End()
 		s.performanceStats.SetEndpointStats(
 			common.PathGetHeader,
@@ -794,10 +788,7 @@ func (s *Server) HandleGetPayload(w http.ResponseWriter, r *http.Request) {
 			100)
 	}()
 
-	parentSpan := trace.SpanFromContext(r.Context())
-	parentCtx := trace.ContextWithSpan(context.Background(), parentSpan)
-	getPayloadCtx, span := s.tracer.Start(parentCtx, "handleGetPayload-start")
-	defer parentSpan.End()
+	getPayloadCtx, span := s.tracer.Start(r.Context(), "handleGetPayload-start")
 	defer span.End()
 
 	receivedAt := time.Now().UTC()
@@ -981,10 +972,7 @@ func (s *Server) HandleGetPayloadV2(w http.ResponseWriter, r *http.Request) {
 			100)
 	}()
 
-	parentSpan := trace.SpanFromContext(r.Context())
-	parentCtx := trace.ContextWithSpan(context.Background(), parentSpan)
-	getPayloadCtx, span := s.tracer.Start(parentCtx, "handleGetPayloadV2-start")
-	defer parentSpan.End()
+	getPayloadCtx, span := s.tracer.Start(r.Context(), "handleGetPayloadV2-start")
 	defer span.End()
 
 	receivedAt := time.Now().UTC()
@@ -1153,17 +1141,31 @@ func respondError(ctx context.Context, parentSpan trace.Span, method string, w h
 	_, span := tracer.Start(ctx, "respondError-"+method)
 	defer span.End()
 
+	if err == nil {
+		parentSpan.SetAttributes(
+			attribute.Int("responseCode", http.StatusInternalServerError),
+		)
+		log.Error().Str("method", method).Msg("respondError called with nil err")
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		span.SetStatus(codes.Error, "nil err passed to respondError")
+		return
+	}
+
 	resp, ok := err.(*ErrorResp)
-	parentSpan.SetAttributes(
-		attribute.String("Err", err.Error()),
-		attribute.Int("responseCode", resp.ErrorCode()),
-	)
-	if !ok {
+	if !ok || resp == nil {
+		parentSpan.SetAttributes(
+			attribute.String("Err", err.Error()),
+			attribute.Int("responseCode", http.StatusInternalServerError),
+		)
 		log.Error().Str("method", method).Err(err).Msg("failed to typecast error response")
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		span.SetStatus(codes.Error, "failed to typecast error response")
 		return
 	}
+	parentSpan.SetAttributes(
+		attribute.String("Err", err.Error()),
+		attribute.Int("responseCode", resp.ErrorCode()),
+	)
 	w.WriteHeader(resp.Code)
 	log.Error().Str("method", method).Msg(method + " failed")
 	if resp.Message != "" && resp.Code != http.StatusNoContent { // HTTP status "No Content" implies that no message body should be included in the response.


### PR DESCRIPTION
## 📝 Summary

<!--- A general summary of your changes -->
-  Handle panic while responding error for getPayloadv2
```
a41528cc289fd6a32ea211d17c0df3cf4ea3990ba55ab7cc9a981f","uKey":"slot_13172883_bHash_0x9afef6e4cd5bd7b7c4ac7e9b703cc99bd3c7df17920f19191decba5065464e18_pHash_0xa9efc78744a41528cc289fd6a32ea211d17c0df3cf4ea3990ba55ab7cc9a981f","latency":4,"duration":434.658371,"slotStartTime":1764898619000,"msIntoSlot":2416,"blockValue":"0.014066056214481467","svcGetPayloadV2Duration":434.737321,"currentTime":"2025-12-05T01:37:01.857349","time":"2025-12-05T01:37:01.85735","message":"Error in GetPayloadV2"}
2025/12/05 01:37:01 http: panic serving 16.62.218.168:26321: runtime error: invalid memory address or nil pointer dereference
goroutine 16254117 [running]:
net/http.(*conn).serve.func1()
        /Users/jonzacks/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.2.darwin-arm64/src/net/http/server.go:1947 +0xbe
panic({0x1e03f00?, 0x3bb45d0?})
        /Users/jonzacks/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.2.darwin-arm64/src/runtime/panic.go:792 +0x132
go.opentelemetry.io/otel/sdk/trace.(*recordingSpan).End.deferwrap1()
        /Users/jonzacks/go/pkg/mod/go.opentelemetry.io/otel/sdk@v1.36.0/trace/span.go:467 +0x25
go.opentelemetry.io/otel/sdk/trace.(*recordingSpan).End(0xc005440000, {0x0, 0x0, 0xc00603fdc0?})
        /Users/jonzacks/go/pkg/mod/go.opentelemetry.io/otel/sdk@v1.36.0/trace/span.go:506 +0xb6e
panic({0x1e03f00?, 0x3bb45d0?})
        /Users/jonzacks/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.2.darwin-arm64/src/runtime/panic.go:792 +0x132
go.opentelemetry.io/otel/sdk/trace.(*recordingSpan).End.deferwrap1()
        /Users/jonzacks/go/pkg/mod/go.opentelemetry.io/otel/sdk@v1.36.0/trace/span.go:467 +0x25
go.opentelemetry.io/otel/sdk/trace.(*recordingSpan).End(0xc006bd45a0, {0x0, 0x0, 0xc00603fdc0?})
        /Users/jonzacks/go/pkg/mod/go.opentelemetry.io/otel/sdk@v1.36.0/trace/span.go:506 +0xb6e
panic({0x1e03f00?, 0x3bb45d0?})
        /Users/jonzacks/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.2.darwin-arm64/src/runtime/panic.go:792 +0x132
github.com/bloXroute-Labs/relayproxy.respondError({0x27dedd8, 0xc004927ad0}, {0x27f1af0, 0xc005440000}, {0x218314a, 0xc}, {0x27d43f0, 0xc00e0962a0}, {0x27bec60, 0x0}, ...)
        /Users/jonzacks/workspace/bloxroute/rproxy/relayproxy/server.go:1167 +0x409
github.com/bloXroute-Labs/relayproxy.(*Server).HandleGetPayloadV2(0xc0001b0dc0, {0x27d43f0, 0xc00e0962a0}, 0xc00d32ec80)
        /Users/jonzacks/workspace/bloxroute/rproxy/relayproxy/server.go:1110 +0x41b5
net/http.HandlerFunc.ServeHTTP(0x27dedd8?, {0x27d43f0?, 0xc00e0962a0?}, 0xc0162002c0?)
        /Users/jonzacks/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.2.darwin-arm64/src/net/http/server.go:2294 +0x29
github.com/bloXroute-Labs/relayproxy.(*Server).authorize(0xc0001b0dc0, {0x27d43f0, 0xc00e0962a0}, 0xc00d32e780, {0x27bc860, 0xc000bea930}, 0x0)
        /Users/jonzacks/workspace/bloxroute/rproxy/relayproxy/server.go:333 +0x10dc
github.com/bloXroute-Labs/relayproxy.(*Server).Middleware-fm.(*Server).Middleware.func1({0x27d43f0?, 0xc00e0962a0?}, 0x1?)
        /Users/jonzacks/workspace/bloxroute/rproxy/relayproxy/server.go:187 +0x38
--
        /Users/jonzacks/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.2.darwin-arm64/src/net/http/server.go:2102 +0x625
created by net/http.(*Server).Serve in goroutine 1
        /Users/jonzacks/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.2.darwin-arm64/src/net/http/server.go:3454 +0x485
```
## 💡 Motivation and Context

<!--- (Optional) Why is this change required? What problem does it solve? Remove this section if not applicable. -->

---

## ✅ I have completed the following steps:

* [ ] Run `make lint`
* [ ] Run `make test`
* [ ] Run `go mod tidy`
* [ ] Added tests (if applicable)
