### PR TITLE
use sync map to handle panic

### DIFF
--- a/cmd/relayproxy/main.go
+++ b/cmd/relayproxy/main.go
@@ -449,6 +449,8 @@ func main() {
 		svc.StartStreamHeaders(_ctx, wg)
 	}(ctx)
 
+	go server.CleanupGetHeaderRateLimitData(ctx)
+
 	if err := server.Start(); err != nil {
 		l.Fatal().Err(err).Msg("failed to start relay proxy server")
 	}

--- a/server.go
+++ b/server.go
@@ -42,7 +42,7 @@ const (
 	VouchCluster            = "setup"
 	statsNamePerformance    = "performanceStats"
 
-	keepOld uint64 = 100 // slot to keep for ip rate limit
+	keepOld uint64 = 10 // slot to keep for ip rate limit
 )
 
 type contextKey string
@@ -304,7 +304,7 @@ func (s *Server) authorize(w http.ResponseWriter, r *http.Request, next http.Han
 	if isGetHeader && !isWhitelisted {
 		currentSlot := uint64(CalculateCurrentSlot(s.beaconGenesisTime, s.secondsPerSlot))
 
-		if !s.allowGetHeaderForSlot(clientIP, currentSlot, keepOld) {
+		if !s.allowGetHeaderForSlot(clientIP, currentSlot) {
 			s.logger.Warn().
 				Str("authHeader", authHeader).
 				Str("accountID", accountID).
@@ -323,7 +323,7 @@ func (s *Server) authorize(w http.ResponseWriter, r *http.Request, next http.Han
 	next.ServeHTTP(w, r.WithContext(ctx))
 }
 
-func (s *Server) allowGetHeaderForSlot(clientIP string, currentSlot, keepOld uint64) bool {
+func (s *Server) allowGetHeaderForSlot(clientIP string, currentSlot uint64) bool {
 	ipSet, _ := s.ghRatelimit.slotToIPToGHRequest.LoadOrStore(
 		currentSlot,
 		NewStringMapOf[struct{}](),
@@ -333,10 +333,35 @@ func (s *Server) allowGetHeaderForSlot(clientIP string, currentSlot, keepOld uin
 		return false
 	}
 
-	if currentSlot > keepOld {
-		s.ghRatelimit.slotToIPToGHRequest.Delete(currentSlot - keepOld)
-	}
 	return true
+}
+
+func (s *Server) CleanupGetHeaderRateLimitData(ctx context.Context) {
+
+	ticker := time.NewTicker(time.Second * 60)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			s.cleanupGetHeaderRateLimitOnce()
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func (s *Server) cleanupGetHeaderRateLimitOnce() {
+	currentSlot := uint64(CalculateCurrentSlot(s.beaconGenesisTime, s.secondsPerSlot))
+	cutoff := uint64(0)
+	if currentSlot > keepOld {
+		cutoff = currentSlot - keepOld
+	}
+	s.ghRatelimit.slotToIPToGHRequest.Range(func(slot uint64, _ *SyncMap[string, struct{}]) bool {
+		if slot < cutoff {
+			s.ghRatelimit.slotToIPToGHRequest.Delete(slot)
+		}
+		return true
+	})
 }
 
 func (s *Server) HandleOptions(w http.ResponseWriter, r *http.Request) {

--- a/server.go
+++ b/server.go
@@ -42,7 +42,7 @@ const (
 	VouchCluster            = "setup"
 	statsNamePerformance    = "performanceStats"
 
-	keepOld uint64 = 256
+	keepOld uint64 = 100 // slot to keep for ip rate limit
 )
 
 type contextKey string
@@ -70,7 +70,7 @@ type Server struct {
 
 	authHeaderP2P string // Added until vouch support query params
 
-	ghRatelimit      *SyncMap[string, uint64]
+	ghRatelimit      GetHeaderRateLimitInfo
 	accountsLists    *AccountsLists
 	NodeID           string
 	AdminAccountID   string
@@ -84,6 +84,10 @@ type Server struct {
 		GetHeaderStartTimeUnixMS string,
 		ExtraData string,
 	) error
+}
+
+type GetHeaderRateLimitInfo struct {
+	slotToIPToGHRequest *SyncMap[uint64, *SyncMap[string, struct{}]]
 }
 
 type DelaySettings struct {
@@ -111,7 +115,9 @@ func NewServer(opts ...ServerOption) *Server {
 		opt(server)
 	}
 
-	server.ghRatelimit = NewStringMapOf[uint64]()
+	server.ghRatelimit = GetHeaderRateLimitInfo{
+		slotToIPToGHRequest: NewIntegerMapOf[uint64, *SyncMap[string, struct{}]](),
+	}
 
 	return server
 }
@@ -298,16 +304,15 @@ func (s *Server) authorize(w http.ResponseWriter, r *http.Request, next http.Han
 	if isGetHeader && !isWhitelisted {
 		currentSlot := uint64(CalculateCurrentSlot(s.beaconGenesisTime, s.secondsPerSlot))
 
-		prev, exist := s.ghRatelimit.LoadOrStore(clientIP, currentSlot)
-		if exist && prev == currentSlot {
+		if !s.allowGetHeaderForSlot(clientIP, currentSlot, keepOld) {
 			s.logger.Warn().
 				Str("authHeader", authHeader).
 				Str("accountID", accountID).
 				Str("ip", clientIP).
 				Str("url", parsedURL.String()).
+				Uint64("slot", currentSlot).
 				Err(err).Msg("get header rate limit exceeded")
-
-			http.Error(w, "only one getheader request allowed per slot per validator", http.StatusTooManyRequests)
+			http.Error(w, "only one getheader request allowed per slot per ip", http.StatusTooManyRequests)
 			return
 		}
 	}
@@ -316,6 +321,22 @@ func (s *Server) authorize(w http.ResponseWriter, r *http.Request, next http.Han
 	ctx = context.WithValue(ctx, keyAuthHeader, authHeader)
 	ctx = context.WithValue(ctx, keyAccountID, accountID)
 	next.ServeHTTP(w, r.WithContext(ctx))
+}
+
+func (s *Server) allowGetHeaderForSlot(clientIP string, currentSlot, keepOld uint64) bool {
+	ipSet, _ := s.ghRatelimit.slotToIPToGHRequest.LoadOrStore(
+		currentSlot,
+		NewStringMapOf[struct{}](),
+	)
+
+	if _, exist := ipSet.LoadOrStore(clientIP, struct{}{}); exist {
+		return false
+	}
+
+	if currentSlot > keepOld {
+		s.ghRatelimit.slotToIPToGHRequest.Delete(currentSlot - keepOld)
+	}
+	return true
 }
 
 func (s *Server) HandleOptions(w http.ResponseWriter, r *http.Request) {

--- a/server.go
+++ b/server.go
@@ -41,6 +41,8 @@ const (
 	HeaderKeySlotUID        = "X-MEVBoost-SlotID"
 	VouchCluster            = "setup"
 	statsNamePerformance    = "performanceStats"
+
+	keepOld uint64 = 256
 )
 
 type contextKey string
@@ -68,7 +70,7 @@ type Server struct {
 
 	authHeaderP2P string // Added until vouch support query params
 
-	ghRatelimit      GetHeaderRateLimitInfo
+	ghRatelimit      *SyncMap[uint64, struct{}]
 	accountsLists    *AccountsLists
 	NodeID           string
 	AdminAccountID   string
@@ -82,11 +84,6 @@ type Server struct {
 		GetHeaderStartTimeUnixMS string,
 		ExtraData string,
 	) error
-}
-
-type GetHeaderRateLimitInfo struct {
-	lastGetHeaderRequest uint64
-	slotToIPToGHRequest  *SyncMap[uint64, map[string]bool]
 }
 
 type DelaySettings struct {
@@ -114,10 +111,7 @@ func NewServer(opts ...ServerOption) *Server {
 		opt(server)
 	}
 
-	server.ghRatelimit = GetHeaderRateLimitInfo{
-		lastGetHeaderRequest: 0,
-		slotToIPToGHRequest:  NewIntegerMapOf[uint64, map[string]bool](),
-	}
+	server.ghRatelimit = NewIntegerMapOf[uint64, struct{}]()
 
 	return server
 }
@@ -303,28 +297,20 @@ func (s *Server) authorize(w http.ResponseWriter, r *http.Request, next http.Han
 
 	if isGetHeader && !isWhitelisted {
 		currentSlot := uint64(CalculateCurrentSlot(s.beaconGenesisTime, s.secondsPerSlot))
-		slotIPRequests, exists := s.ghRatelimit.slotToIPToGHRequest.Load(currentSlot)
-		if !exists || slotIPRequests == nil {
-			slotIPRequests = make(map[string]bool)
-		} else {
-			if slotIPRequests[clientIP] {
-				s.logger.Warn().
-					Str("authHeader", authHeader).
-					Str("accountID", accountID).
-					Str("ip", clientIP).
-					Str("url", parsedURL.String()).
-					Err(err).Msg("get header rate limit exceeded")
-				// Not saying IP because that encourages people to work around the rate limit
-				http.Error(w, "only one getheader request allowed per slot per validator", http.StatusTooManyRequests)
-				return
-			}
+		if _, exist := s.ghRatelimit.LoadAndStore(currentSlot, struct{}{}); exist {
+			s.logger.Warn().
+				Str("authHeader", authHeader).
+				Str("accountID", accountID).
+				Str("ip", clientIP).
+				Str("url", parsedURL.String()).
+				Err(err).Msg("get header rate limit exceeded")
+			// Not saying IP because that encourages people to work around the rate limit
+			http.Error(w, "only one getheader request allowed per slot per validator", http.StatusTooManyRequests)
+			return
 		}
-		slotIPRequests[clientIP] = true
-		s.ghRatelimit.slotToIPToGHRequest.Store(currentSlot, slotIPRequests)
-		for j := s.ghRatelimit.lastGetHeaderRequest - 100; j < currentSlot-100; j++ {
-			s.ghRatelimit.slotToIPToGHRequest.Delete(j)
+		if currentSlot > keepOld {
+			s.ghRatelimit.Delete(currentSlot - keepOld)
 		}
-		s.ghRatelimit.lastGetHeaderRequest = currentSlot
 	}
 	ctx = context.WithValue(ctx, keyParsedURL, parsedURL)
 	ctx = context.WithValue(ctx, keyClientIP, clientIP)

--- a/server.go
+++ b/server.go
@@ -70,7 +70,7 @@ type Server struct {
 
 	authHeaderP2P string // Added until vouch support query params
 
-	ghRatelimit      *SyncMap[uint64, struct{}]
+	ghRatelimit      *SyncMap[string, uint64]
 	accountsLists    *AccountsLists
 	NodeID           string
 	AdminAccountID   string
@@ -111,7 +111,7 @@ func NewServer(opts ...ServerOption) *Server {
 		opt(server)
 	}
 
-	server.ghRatelimit = NewIntegerMapOf[uint64, struct{}]()
+	server.ghRatelimit = NewStringMapOf[uint64]()
 
 	return server
 }
@@ -297,19 +297,18 @@ func (s *Server) authorize(w http.ResponseWriter, r *http.Request, next http.Han
 
 	if isGetHeader && !isWhitelisted {
 		currentSlot := uint64(CalculateCurrentSlot(s.beaconGenesisTime, s.secondsPerSlot))
-		if _, exist := s.ghRatelimit.LoadAndStore(currentSlot, struct{}{}); exist {
+
+		prev, exist := s.ghRatelimit.LoadOrStore(clientIP, currentSlot)
+		if exist && prev == currentSlot {
 			s.logger.Warn().
 				Str("authHeader", authHeader).
 				Str("accountID", accountID).
 				Str("ip", clientIP).
 				Str("url", parsedURL.String()).
 				Err(err).Msg("get header rate limit exceeded")
-			// Not saying IP because that encourages people to work around the rate limit
+
 			http.Error(w, "only one getheader request allowed per slot per validator", http.StatusTooManyRequests)
 			return
-		}
-		if currentSlot > keepOld {
-			s.ghRatelimit.Delete(currentSlot - keepOld)
 		}
 	}
 	ctx = context.WithValue(ctx, keyParsedURL, parsedURL)

--- a/server_test.go
+++ b/server_test.go
@@ -8,6 +8,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/go-chi/chi/v5"
@@ -527,5 +529,107 @@ func TestServer_Middleware(t *testing.T) {
 			handler.ServeHTTP(rr, req)
 			assert.Equal(t, tc.expectedCode, rr.Code)
 		})
+	}
+}
+
+func newTestServerForRateLimit() *Server {
+	s := &Server{}
+	s.ghRatelimit = GetHeaderRateLimitInfo{
+		slotToIPToGHRequest: NewIntegerMapOf[uint64, *SyncMap[string, struct{}]](),
+	}
+	return s
+}
+
+func TestAllowGetHeader_FirstRequestAllowed(t *testing.T) {
+	s := newTestServerForRateLimit()
+
+	allowed := s.allowGetHeaderForSlot("1.2.3.4", 100, keepOld)
+	if !allowed {
+		t.Fatalf("expected first request to be allowed")
+	}
+}
+
+func TestAllowGetHeader_SameSlotSameIP_SecondRejected(t *testing.T) {
+	s := newTestServerForRateLimit()
+
+	if !s.allowGetHeaderForSlot("1.2.3.4", 100, keepOld) {
+		t.Fatalf("expected first request to be allowed")
+	}
+	if s.allowGetHeaderForSlot("1.2.3.4", 100, keepOld) {
+		t.Fatalf("expected second request same slot+ip to be rejected")
+	}
+}
+
+func TestAllowGetHeader_SameSlotDifferentIP_BothAllowed(t *testing.T) {
+	s := newTestServerForRateLimit()
+
+	if !s.allowGetHeaderForSlot("1.2.3.4", 100, keepOld) {
+		t.Fatalf("expected ip A to be allowed")
+	}
+	if !s.allowGetHeaderForSlot("5.6.7.8", 100, keepOld) {
+		t.Fatalf("expected ip B to be allowed in same slot")
+	}
+}
+
+func TestAllowGetHeader_NextSlotSameIP_AllowedAgain(t *testing.T) {
+	s := newTestServerForRateLimit()
+
+	if !s.allowGetHeaderForSlot("1.2.3.4", 100, keepOld) {
+		t.Fatalf("expected slot 100 allowed")
+	}
+	// New slot => should be allowed again
+	if !s.allowGetHeaderForSlot("1.2.3.4", 101, keepOld) {
+		t.Fatalf("expected slot 101 allowed for same IP")
+	}
+}
+
+func TestAllowGetHeader_CleanupDeletesOldSlotBucket(t *testing.T) {
+	s := newTestServerForRateLimit()
+	keepOldSlot := uint64(2)
+
+	if !s.allowGetHeaderForSlot("1.2.3.4", 10, keepOldSlot) {
+		t.Fatalf("expected slot 10 allowed")
+	}
+
+	if !s.allowGetHeaderForSlot("5.6.7.8", 13, keepOldSlot) {
+		t.Fatalf("expected slot 13 allowed")
+	}
+
+	if !s.allowGetHeaderForSlot("9.9.9.9", 14, keepOldSlot) {
+		t.Fatalf("expected slot 14 allowed")
+	}
+
+	if _, exists := s.ghRatelimit.slotToIPToGHRequest.Load(12); exists {
+		t.Fatalf("expected slot 12 bucket to be deleted by cleanup")
+	}
+}
+
+func TestAllowGetHeader_ConcurrentSameSlotSameIP_OnlyOneAllowed(t *testing.T) {
+	s := newTestServerForRateLimit()
+
+	const (
+		nGoroutines = 200
+		slot        = uint64(100)
+		keepOld     = uint64(256)
+		ip          = "1.2.3.4"
+	)
+
+	var allowedCount int64
+	var wg sync.WaitGroup
+	wg.Add(nGoroutines)
+
+	for i := 0; i < nGoroutines; i++ {
+		go func() {
+			defer wg.Done()
+			if s.allowGetHeaderForSlot(ip, slot, keepOld) {
+				atomic.AddInt64(&allowedCount, 1)
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	if allowedCount != 1 {
+		t.Fatalf("expected exactly 1 allowed under concurrency; got %d", allowedCount)
 	}
 }

--- a/server_test.go
+++ b/server_test.go
@@ -543,7 +543,7 @@ func newTestServerForRateLimit() *Server {
 func TestAllowGetHeader_FirstRequestAllowed(t *testing.T) {
 	s := newTestServerForRateLimit()
 
-	allowed := s.allowGetHeaderForSlot("1.2.3.4", 100, keepOld)
+	allowed := s.allowGetHeaderForSlot("1.2.3.4", 100)
 	if !allowed {
 		t.Fatalf("expected first request to be allowed")
 	}
@@ -552,10 +552,10 @@ func TestAllowGetHeader_FirstRequestAllowed(t *testing.T) {
 func TestAllowGetHeader_SameSlotSameIP_SecondRejected(t *testing.T) {
 	s := newTestServerForRateLimit()
 
-	if !s.allowGetHeaderForSlot("1.2.3.4", 100, keepOld) {
+	if !s.allowGetHeaderForSlot("1.2.3.4", 100) {
 		t.Fatalf("expected first request to be allowed")
 	}
-	if s.allowGetHeaderForSlot("1.2.3.4", 100, keepOld) {
+	if s.allowGetHeaderForSlot("1.2.3.4", 100) {
 		t.Fatalf("expected second request same slot+ip to be rejected")
 	}
 }
@@ -563,10 +563,10 @@ func TestAllowGetHeader_SameSlotSameIP_SecondRejected(t *testing.T) {
 func TestAllowGetHeader_SameSlotDifferentIP_BothAllowed(t *testing.T) {
 	s := newTestServerForRateLimit()
 
-	if !s.allowGetHeaderForSlot("1.2.3.4", 100, keepOld) {
+	if !s.allowGetHeaderForSlot("1.2.3.4", 100) {
 		t.Fatalf("expected ip A to be allowed")
 	}
-	if !s.allowGetHeaderForSlot("5.6.7.8", 100, keepOld) {
+	if !s.allowGetHeaderForSlot("5.6.7.8", 100) {
 		t.Fatalf("expected ip B to be allowed in same slot")
 	}
 }
@@ -574,33 +574,12 @@ func TestAllowGetHeader_SameSlotDifferentIP_BothAllowed(t *testing.T) {
 func TestAllowGetHeader_NextSlotSameIP_AllowedAgain(t *testing.T) {
 	s := newTestServerForRateLimit()
 
-	if !s.allowGetHeaderForSlot("1.2.3.4", 100, keepOld) {
+	if !s.allowGetHeaderForSlot("1.2.3.4", 100) {
 		t.Fatalf("expected slot 100 allowed")
 	}
 	// New slot => should be allowed again
-	if !s.allowGetHeaderForSlot("1.2.3.4", 101, keepOld) {
+	if !s.allowGetHeaderForSlot("1.2.3.4", 101) {
 		t.Fatalf("expected slot 101 allowed for same IP")
-	}
-}
-
-func TestAllowGetHeader_CleanupDeletesOldSlotBucket(t *testing.T) {
-	s := newTestServerForRateLimit()
-	keepOldSlot := uint64(2)
-
-	if !s.allowGetHeaderForSlot("1.2.3.4", 10, keepOldSlot) {
-		t.Fatalf("expected slot 10 allowed")
-	}
-
-	if !s.allowGetHeaderForSlot("5.6.7.8", 13, keepOldSlot) {
-		t.Fatalf("expected slot 13 allowed")
-	}
-
-	if !s.allowGetHeaderForSlot("9.9.9.9", 14, keepOldSlot) {
-		t.Fatalf("expected slot 14 allowed")
-	}
-
-	if _, exists := s.ghRatelimit.slotToIPToGHRequest.Load(12); exists {
-		t.Fatalf("expected slot 12 bucket to be deleted by cleanup")
 	}
 }
 
@@ -610,7 +589,6 @@ func TestAllowGetHeader_ConcurrentSameSlotSameIP_OnlyOneAllowed(t *testing.T) {
 	const (
 		nGoroutines = 200
 		slot        = uint64(100)
-		keepOld     = uint64(256)
 		ip          = "1.2.3.4"
 	)
 
@@ -621,7 +599,7 @@ func TestAllowGetHeader_ConcurrentSameSlotSameIP_OnlyOneAllowed(t *testing.T) {
 	for i := 0; i < nGoroutines; i++ {
 		go func() {
 			defer wg.Done()
-			if s.allowGetHeaderForSlot(ip, slot, keepOld) {
+			if s.allowGetHeaderForSlot(ip, slot) {
 				atomic.AddInt64(&allowedCount, 1)
 			}
 		}()
@@ -631,5 +609,34 @@ func TestAllowGetHeader_ConcurrentSameSlotSameIP_OnlyOneAllowed(t *testing.T) {
 
 	if allowedCount != 1 {
 		t.Fatalf("expected exactly 1 allowed under concurrency; got %d", allowedCount)
+	}
+}
+
+func TestCleanupGetHeaderRateLimit_DeletesSlotsOlderThanCutoff1(t *testing.T) {
+	s := newTestServerForRateLimit()
+
+	s.secondsPerSlot = 12
+	s.beaconGenesisTime = 0
+
+	currentSlot := uint64(CalculateCurrentSlot(s.beaconGenesisTime, s.secondsPerSlot))
+	if currentSlot <= keepOld {
+		t.Fatalf("test requires currentSlot(%d) > keepOld(%d)", currentSlot, keepOld)
+	}
+	cutoff := currentSlot - keepOld
+
+	_ = s.allowGetHeaderForSlot("1.2.3.4", cutoff-1)
+	_ = s.allowGetHeaderForSlot("1.2.3.4", cutoff)
+	_ = s.allowGetHeaderForSlot("1.2.3.4", cutoff+1)
+
+	s.cleanupGetHeaderRateLimitOnce()
+
+	if _, exists := s.ghRatelimit.slotToIPToGHRequest.Load(cutoff - 1); exists {
+		t.Fatalf("expected slot %d bucket to be deleted (slot < cutoff=%d)", cutoff-1, cutoff)
+	}
+	if _, exists := s.ghRatelimit.slotToIPToGHRequest.Load(cutoff); !exists {
+		t.Fatalf("expected slot %d bucket to remain (slot == cutoff=%d)", cutoff, cutoff)
+	}
+	if _, exists := s.ghRatelimit.slotToIPToGHRequest.Load(cutoff + 1); !exists {
+		t.Fatalf("expected slot %d bucket to remain (slot > cutoff=%d)", cutoff+1, cutoff)
 	}
 }


### PR DESCRIPTION
## 📝 Summary

<!--- A general summary of your changes -->
Fix for concurrent map access panic on getheader ratelimit
```
goroutine 4034538 [running]:
internal/runtime/maps.fatal({0x2196cd7?, 0x1e52b40?})
        /Users/jonzacks/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.2.darwin-arm64/src/runtime/panic.go:1058 +0x18
github.com/bloXroute-Labs/relayproxy.(*Server).authorize(0xc0000c8c60, {0x27d43d0, 0xc004ad3340}, 0xc0037faa00, {0x27bc840, 0xc0007e1220}, 0x1)
        /Users/jonzacks/workspace/bloxroute/rproxy/relayproxy/server.go:322 +0x90e
github.com/bloXroute-Labs/relayproxy.(*Server).MiddlewareGetHeader-fm.(*Server).MiddlewareGetHeader.func1({0x27d43d0?, 0xc004ad3340?}, 0x2?)
        /Users/jonzacks/workspace/bloxroute/rproxy/relayproxy/server.go:193 +0x3b
net/http.HandlerFunc.ServeHTTP(0xc004bdc4c7?, {0x27d43d0?, 0xc004ad3340?}, 0xc00b13f910?)
        /Users/jonzacks/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.2.darwin-arm64/src/net/http/server.go:2294 +0x29
github.com/go-chi/chi/v5.(*ChainHandler).ServeHTTP(0xc0059f3e00?, {0x27d43d0?, 0xc004ad3340?}, 0xc004bdc464?)
        /Users/jonzacks/go/pkg/mod/github.com/go-chi/chi/v5@v5.1.0/chain.go:31 +0x26
github.com/go-chi/chi/v5.(*Mux).routeHTTP(0xc0006766c0, {0x27d43d0, 0xc004ad3340}, 0xc0037faa00)
        /Users/jonzacks/go/pkg/mod/github.com/go-chi/chi/v5@v5.1.0/mux.go:459 +0x2e2
        ```

## 💡 Motivation and Context

<!--- (Optional) Why is this change required? What problem does it solve? Remove this section if not applicable. -->

---

## ✅ I have completed the following steps:

* [ ] Run `make lint`
* [ ] Run `make test`
* [ ] Run `go mod tidy`
* [ ] Added tests (if applicable)
