### PR TITLE
return error instead of errResp for getPayloadv2

### DIFF
--- a/getpayloadv2.go
+++ b/getpayloadv2.go
@@ -17,7 +17,7 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-func (s *Service) GetPayloadV2(ctx context.Context, log *zerolog.Logger, in *PayloadRequestParams) *ErrorResp {
+func (s *Service) GetPayloadV2(ctx context.Context, log *zerolog.Logger, in *PayloadRequestParams) error {
 	startTime := time.Now().UTC()
 	id := uuid.NewString()
 

--- a/server_test.go
+++ b/server_test.go
@@ -127,7 +127,7 @@ func (m *MockService) GetPayload(ctx context.Context, log *zerolog.Logger, in *P
 	return nil, nil
 }
 
-func (m *MockService) GetPayloadV2(ctx context.Context, log *zerolog.Logger, in *PayloadRequestParams) *ErrorResp {
+func (m *MockService) GetPayloadV2(ctx context.Context, log *zerolog.Logger, in *PayloadRequestParams) error {
 	return nil
 }
 

--- a/service.go
+++ b/service.go
@@ -65,7 +65,7 @@ type IService interface {
 	RegisterValidator(ctx context.Context, log *zerolog.Logger, outgoingCtx context.Context, in *RegistrationParams) (any, error)
 	GetHeader(parentSpan trace.Span, ctx context.Context, log *zerolog.Logger, in *HeaderRequestParams) (json.RawMessage, *common.OnHeaderDeliveredParams, error)
 	GetPayload(ctx context.Context, log *zerolog.Logger, in *PayloadRequestParams) (*common.VersionedPayloadInfo, error)
-	GetPayloadV2(ctx context.Context, log *zerolog.Logger, in *PayloadRequestParams) *ErrorResp
+	GetPayloadV2(ctx context.Context, log *zerolog.Logger, in *PayloadRequestParams) error
 }
 
 type Service struct {

--- a/service_test.go
+++ b/service_test.go
@@ -303,6 +303,7 @@ func TestBlockCancellation(t *testing.T) {
 		time.Now(),
 		"",
 		nil,
+		false,
 	)
 	bidsMap.Store(testBuilderPubkey1, lowBid)
 
@@ -320,6 +321,7 @@ func TestBlockCancellation(t *testing.T) {
 		time.Now(),
 		"",
 		nil,
+		false,
 	)
 	bidsMap.Store(testBuilderPubkey2, highBid)
 
@@ -337,6 +339,7 @@ func TestBlockCancellation(t *testing.T) {
 		time.Now(),
 		"",
 		nil,
+		false,
 	)
 	bidsMap.Store(testBuilderPubkey3, mediumBid)
 
@@ -382,6 +385,7 @@ func TestBlockCancellationForSamePubKey(t *testing.T) {
 		time.Now(),
 		"",
 		nil,
+		false,
 	)
 	bidsMap.Store(testBuilderPubkey1, lowBid)
 
@@ -399,6 +403,7 @@ func TestBlockCancellationForSamePubKey(t *testing.T) {
 		time.Now(),
 		"",
 		nil,
+		false,
 	)
 	bidsMap.Store(testBuilderPubkey1, highBid)
 
@@ -416,6 +421,7 @@ func TestBlockCancellationForSamePubKey(t *testing.T) {
 		time.Now(),
 		"",
 		nil,
+		false,
 	)
 	bidsMap.Store(testBuilderPubkey1, mediumBid)
 
@@ -434,6 +440,7 @@ func TestBlockCancellationForSamePubKey(t *testing.T) {
 		time.Now(),
 		"",
 		nil,
+		false,
 	)
 	bidsMap.Store(testBuilderPubkey2, lowBid1)
 
@@ -451,6 +458,7 @@ func TestBlockCancellationForSamePubKey(t *testing.T) {
 		time.Now(),
 		"",
 		nil,
+		false,
 	)
 	bidsMap.Store(testBuilderPubkey2, mediumBid1)
 
@@ -468,6 +476,7 @@ func TestBlockCancellationForSamePubKey(t *testing.T) {
 		time.Now(),
 		"",
 		nil,
+		false,
 	)
 	bidsMap.Store(testBuilderPubkey2, highBid1)
 
@@ -486,6 +495,7 @@ func TestBlockCancellationForSamePubKey(t *testing.T) {
 		time.Now(),
 		"",
 		nil,
+		false,
 	)
 	bidsMap.Store(testBuilderPubkey3, mediumBid2)
 
@@ -503,6 +513,7 @@ func TestBlockCancellationForSamePubKey(t *testing.T) {
 		time.Now(),
 		"",
 		nil,
+		false,
 	)
 	bidsMap.Store(testBuilderPubkey3, highBid2)
 
@@ -520,6 +531,7 @@ func TestBlockCancellationForSamePubKey(t *testing.T) {
 		time.Now(),
 		"",
 		nil,
+		false,
 	)
 	bidsMap.Store(testBuilderPubkey3, lowBid2)
 


### PR DESCRIPTION
## 📝 Summary

<!--- A general summary of your changes -->

https://bloxroute.atlassian.net/browse/MEV-1780
- retun error instead of ErrorResp

## 💡 Motivation and Context

<!--- (Optional) Why is this change required? What problem does it solve? Remove this section if not applicable. -->

---

When a *ErrorResp  is stored inside an error interface, some time Go can produce a non--nil interface value holding a nil pointer.This caused the below situation

- err != nil is true
- but err.(*ErrorResp) yields resp == nil
causing misleading “failed to typecast” / “nilErrorResp” behavior in respondError.

## ✅ I have completed the following steps:

* [x] Run `make lint`
* [x] Run `make test`
* [ ] Run `go mod tidy`
* [ ] Added tests (if applicable)
