### PR TITLE
MEV-1765, MEV-1787: Slot stats use 1st get payload

### DIFF
--- a/getheader.go
+++ b/getheader.go
@@ -268,10 +268,10 @@ func (s *Service) GetHeader(parentSpan trace.Span, parentCtx context.Context, lo
 			HeaderSlotUID:             in.SlotUID,
 		}
 
-		if v, ok := s.slotStats.Get(k); !ok {
+		if v, ok := s.slotStatsHeaderEvents.Get(k); !ok {
 			slotStatsSlice := make([]SlotStatsRecord, 0, 5)
 			slotStatsSlice = append(slotStatsSlice, slotStats)
-			s.slotStats.Set(k, slotStatsSlice, cache.DefaultExpiration)
+			s.slotStatsHeaderEvents.Set(k, slotStatsSlice, cache.DefaultExpiration)
 
 			s.slotStatsEventCh <- slotStatsEvent{
 				Slot:      int64(_slot),
@@ -282,7 +282,7 @@ func (s *Service) GetHeader(parentSpan trace.Span, parentCtx context.Context, lo
 		} else {
 			slotStatsSlice := v.([]SlotStatsRecord)
 			slotStatsSlice = append(slotStatsSlice, slotStats)
-			s.slotStats.Set(k, slotStatsSlice, cache.DefaultExpiration)
+			s.slotStatsHeaderEvents.Set(k, slotStatsSlice, cache.DefaultExpiration)
 		}
 
 		headerStats := GetHeaderStatsRecord{

--- a/getpayload.go
+++ b/getpayload.go
@@ -312,7 +312,7 @@ func (s *Service) sendPayloadStats(payload []byte, log *zerolog.Logger, isSuccee
 	// 3 different scenario calling sendPayload stats
 	// case 1 : resp success
 	// case 2: Err case with resp
-	// case 2: Err case with no resp
+	// case 2: Err case with no resp (e.g. timeout)
 	out := resp.Copy()
 	if out.GetSlot() != 0 {
 		slotStartTime = GetSlotStartTime(s.beaconGenesisTime, int64(out.GetSlot()), s.secondsPerSlot)
@@ -406,14 +406,14 @@ func (s *Service) sendPayloadStats(payload []byte, log *zerolog.Logger, isSuccee
 		fallback SlotStatsRecord
 	)
 	k := fmt.Sprintf("slot-%v-parentHash-%v", out.GetSlot(), out.GetParentHash())
-	v, ok := s.slotStats.Get(k)
+	v, ok := s.slotStatsHeaderEvents.Get(k)
 	if ok {
 		if records, success := v.([]SlotStatsRecord); success {
 			for i, record := range records {
 				if i == len(records)-1 {
-					fallback = record
+					fallback = record // for non-matching header/payload
 				}
-				if record.HeaderDeliveredBlockHash == out.GetBlockHash() {
+				if record.HeaderDeliveredBlockHash == out.GetBlockHash() { // win
 					mergeSlotStats(&record, &statsRecord)
 					isRelayProxyWin = true
 					//isSlotUIDMatch = record.HeaderSlotUID == statsRecord.PayloadSlotUID
@@ -427,11 +427,13 @@ func (s *Service) sendPayloadStats(payload []byte, log *zerolog.Logger, isSuccee
 	} else {
 		log.Warn().Str("slotKey", k).Msg("no previous slot stats found, creating new record")
 	}
-	s.slotStatsEvent.Set(k, statsRecord, cache.DefaultExpiration) // replace with updated slot stats
+	// Adds if stats record doesn't exsit or expired and return err otherwise
+	// As the result will cause always recording only 1st getpayload attempt
+	_ = s.slotStatsPayloadEvent.Add(k, statsRecord, cache.DefaultExpiration)
 
 	if isRelayProxyWin {
 		log.Info().Str("slotKey", k).Msg("emit slot won event")
-		s.fluentD.LogToFluentD(fluentstats.Record{
+		s.fluentD.LogToFluentD(fluentstats.Record{ // Is not used atm
 			Type: TypeRelayProxySlotWon,
 			Data: statsRecord,
 		}, time.Now().UTC(), s.nodeID, StatsRelayProxySlotWon)

--- a/getpayload.go
+++ b/getpayload.go
@@ -429,11 +429,7 @@ func (s *Service) sendPayloadStats(payload []byte, log *zerolog.Logger, isSuccee
 	}
 	// Adds if stats record doesn't exsit or expired and return err otherwise
 	// As the result will cause always recording only 1st getpayload attempt
-	if err := s.slotStatsPayloadEvent.Add(k, statsRecord, cache.DefaultExpiration); err == nil {
-		log.Info().Str("slotKey", k).Msg("Slot stats payload event is added on 1st receiving")
-	} else {
-		log.Info().Str("slotKey", k).Msg("Slot stats payload event is already set, skipping adding")
-	}
+	_ = s.slotStatsPayloadEvent.Add(k, statsRecord, cache.DefaultExpiration)
 
 	if isRelayProxyWin {
 		log.Info().Str("slotKey", k).Msg("emit slot won event")

--- a/getpayload.go
+++ b/getpayload.go
@@ -429,7 +429,11 @@ func (s *Service) sendPayloadStats(payload []byte, log *zerolog.Logger, isSuccee
 	}
 	// Adds if stats record doesn't exsit or expired and return err otherwise
 	// As the result will cause always recording only 1st getpayload attempt
-	_ = s.slotStatsPayloadEvent.Add(k, statsRecord, cache.DefaultExpiration)
+	if err := s.slotStatsPayloadEvent.Add(k, statsRecord, cache.DefaultExpiration); err == nil {
+		log.Info().Str("slotKey", k).Msg("Slot stats payload event is added on 1st receiving")
+	} else {
+		log.Info().Str("slotKey", k).Msg("Slot stats payload event is already set, skipping adding")
+	}
 
 	if isRelayProxyWin {
 		log.Info().Str("slotKey", k).Msg("emit slot won event")

--- a/opts.go
+++ b/opts.go
@@ -190,7 +190,7 @@ func WithSvcSecondsPerSlot(secondsPerSlot int64) ServiceOption {
 
 func WithSlotStats(cache *cache.Cache) ServiceOption {
 	return func(s *Service) {
-		s.slotStats = cache
+		s.slotStatsHeaderEvents = cache
 	}
 }
 

--- a/service.go
+++ b/service.go
@@ -86,13 +86,13 @@ type Service struct {
 	preFetchPayloadChan            chan preFetcherFields
 	performancestats               *stat.PerformanceStats
 
-	beaconGenesisTime  int64
-	secondsPerSlot     int64
-	slotStats          *cache.Cache
-	slotStatsEvent     *cache.Cache
-	duplicateSlotCache *cache.Cache
-	slotStatsEventCh   chan slotStatsEvent
-	ethNetworkDetails  *common.EthNetworkDetails
+	beaconGenesisTime     int64
+	secondsPerSlot        int64
+	slotStatsHeaderEvents *cache.Cache
+	slotStatsPayloadEvent *cache.Cache
+	duplicateSlotCache    *cache.Cache
+	slotStatsEventCh      chan slotStatsEvent
+	ethNetworkDetails     *common.EthNetworkDetails
 
 	clients                       []*common.ParentClient
 	streamingClients              []*common.ParentClient
@@ -150,8 +150,8 @@ func NewService(opts ...ServiceOption) *Service {
 
 	svc := &Service{
 		preFetchPayloadChan:           make(chan preFetcherFields, preFetchPayloadChanBufSize),
-		slotStats:                     cache.New(slotStatsCleanupInterval, slotStatsCleanupInterval),
-		slotStatsEvent:                cache.New(slotStatsCleanupInterval, slotStatsCleanupInterval),
+		slotStatsHeaderEvents:         cache.New(slotStatsCleanupInterval, slotStatsCleanupInterval),
+		slotStatsPayloadEvent:         cache.New(slotStatsCleanupInterval, slotStatsCleanupInterval),
 		duplicateSlotCache:            cache.New(duplicateSlotCacheCleanupInterval, duplicateSlotCacheCleanupInterval), // cache to avoid emitting duplicate stats
 		slotStatsEventCh:              make(chan slotStatsEvent, 100),
 		registrationRelayMutex:        sync.Mutex{},
@@ -614,7 +614,7 @@ func (s *Service) skipBidForOldBlockSequenceNumber(cacheKey string, builderPubke
 func (s *Service) EmitSlotStats(ctx context.Context) {
 	for {
 		select {
-		case event := <-s.slotStatsEventCh:
+		case event := <-s.slotStatsEventCh: // On getheader
 			go func() {
 				now := time.Now().UTC()
 				t := GetSlotStartTime(s.beaconGenesisTime, event.Slot, s.secondsPerSlot)
@@ -628,13 +628,14 @@ func (s *Service) EmitSlotStats(ctx context.Context) {
 				defer timer.Stop()
 				select {
 				case <-timer.C:
-					v, ok := s.slotStatsEvent.Get(event.SlotKey)
+					v, ok := s.slotStatsPayloadEvent.Get(event.SlotKey)
 					if ok { //Populated when getPayloadOnly is called
 						record, success := v.(SlotStatsRecord)
 						if success {
 							s.logRecord(record, event.SlotKey, event.UserAgent)
 						} else {
-							slotStats, found := s.slotStats.Get(event.SlotKey)
+							// For now this condition should not happen
+							slotStats, found := s.slotStatsHeaderEvents.Get(event.SlotKey)
 							if found {
 								if records, slotStatsSuccess := slotStats.([]SlotStatsRecord); slotStatsSuccess {
 									slotStatsRecord := records[len(records)-1]
@@ -643,7 +644,7 @@ func (s *Service) EmitSlotStats(ctx context.Context) {
 							}
 						}
 					} else {
-						slotStats, found := s.slotStats.Get(event.SlotKey)
+						slotStats, found := s.slotStatsHeaderEvents.Get(event.SlotKey)
 						if found {
 							if records, slotStatsSuccess := slotStats.([]SlotStatsRecord); slotStatsSuccess {
 								slotStatsRecord := records[len(records)-1]
@@ -963,7 +964,7 @@ func (s *Service) handleStreamBuilderInfoResponse(
 }
 
 func (s *Service) logRecord(record SlotStatsRecord, slotKey string, userAgent string) {
-	s.slotStats.Get(slotKey)
+	s.slotStatsHeaderEvents.Get(slotKey)
 	s.logger.Info().
 		Str("slotKey", slotKey).
 		Str("accountID", record.AccountID).

--- a/service_test.go
+++ b/service_test.go
@@ -223,13 +223,13 @@ func TestService_getPayload(t *testing.T) {
 			f: func(ctx context.Context, req *relaygrpc.GetPayloadRequest, opts ...grpc.CallOption) (*relaygrpc.GetPayloadResponse, error) {
 				return nil, fmt.Errorf("error")
 			},
-			expectedErr: toErrorResp(http.StatusInternalServerError, "relay returned error"),
+			expectedErr: toErrorResp(http.StatusBadRequest, "no execution payload for this request"),
 		},
 		"If getPayload returns empty output": {
 			f: func(ctx context.Context, req *relaygrpc.GetPayloadRequest, opts ...grpc.CallOption) (*relaygrpc.GetPayloadResponse, error) {
 				return nil, nil
 			},
-			expectedErr: toErrorResp(http.StatusInternalServerError, "empty response from relay"),
+			expectedErr: toErrorResp(http.StatusBadRequest, "no execution payload for this request"),
 		},
 	}
 	for testName, tt := range tests {
@@ -246,9 +246,62 @@ func TestService_getPayload(t *testing.T) {
 			svcOpts = append(svcOpts, WithSvcFluentD(fluentstats.NewStats(true, "0.0.0.0:24224")))
 
 			s := NewService(svcOpts...)
+			s.IDataService = &mockDataService{}
 			s.accountsLists = &AccountsLists{AccountIDToInfo: make(map[string]*AccountInfo),
 				AccountNameToInfo: make(map[AccountName]*AccountInfo)}
-			got, err := s.GetPayload(context.Background(), &zerolog.Logger{}, &PayloadRequestParams{AuthHeader: TestAuthHeader})
+
+			// Create a minimal valid signed blinded beacon block payload
+			payload := []byte(`{
+				"message": {
+					"slot": "1",
+					"proposer_index": "1",
+					"parent_root": "0x0000000000000000000000000000000000000000000000000000000000000000",
+					"state_root": "0x0000000000000000000000000000000000000000000000000000000000000000",
+					"body": {
+						"randao_reveal": "0x000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+						"eth1_data": {
+							"deposit_root": "0x0000000000000000000000000000000000000000000000000000000000000000",
+							"deposit_count": "0",
+							"block_hash": "0x0000000000000000000000000000000000000000000000000000000000000000"
+						},
+						"graffiti": "0x0000000000000000000000000000000000000000000000000000000000000000",
+						"proposer_slashings": [],
+						"attester_slashings": [],
+						"attestations": [],
+						"deposits": [],
+						"voluntary_exits": [],
+						"sync_aggregate": {
+							"sync_committee_bits": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+							"sync_committee_signature": "0x000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+						},
+						"execution_payload_header": {
+							"parent_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+							"fee_recipient": "0x0000000000000000000000000000000000000000",
+							"state_root": "0x0000000000000000000000000000000000000000000000000000000000000000",
+							"receipts_root": "0x0000000000000000000000000000000000000000000000000000000000000000",
+							"logs_bloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+							"prev_randao": "0x0000000000000000000000000000000000000000000000000000000000000000",
+							"block_number": "0",
+							"gas_limit": "0",
+							"gas_used": "0",
+							"timestamp": "0",
+							"extra_data": "0x",
+							"base_fee_per_gas": "0",
+							"block_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+							"transactions_root": "0x0000000000000000000000000000000000000000000000000000000000000000",
+							"withdrawals_root": "0x0000000000000000000000000000000000000000000000000000000000000000"
+						},
+						"blob_kzg_commitments": []
+					}
+				},
+				"signature": "0x000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+			}`)
+
+			got, err := s.GetPayload(context.Background(), &zerolog.Logger{}, &PayloadRequestParams{
+				AuthHeader: TestAuthHeader,
+				Payload:    payload,
+				ReceivedAt: time.Now(),
+			})
 			if err == nil {
 				assert.Equal(t, string(tt.expectedSuccess), string(got.GetSszResponse()))
 				return
@@ -1070,4 +1123,66 @@ func TestGetPayloadWithRetry(t *testing.T) {
 
 func TestVouch(t *testing.T) {
 	require.True(t, isVouch("Vouch/1.9.1"))
+}
+
+// mockFlowService is a mock of IFlowService
+type mockFlowService struct{}
+
+func (m *mockFlowService) RecordHeaderFlow(slot uint64, parentHash, blockHash, blockValue, proposerPubkey, nodeID string, ev HeaderFlowEvent) {
+}
+
+func (m *mockFlowService) RecordPrefetchStart(slot uint64, parentHash, blockHash, proposerPubkey, blockValue, nodeID string, ev PrefetchFlowEvent) {
+}
+
+func (m *mockFlowService) RecordPrefetchDone(slot uint64, parentHash, blockHash, proposerPubkey, reqID, getHeaderReqID string, success bool, durationMs int64, source FlowSource, serverURL, serverNodeID string, payloadSizeBytes int, errStr string) {
+}
+
+func (m *mockFlowService) RecordGetPayload(slot uint64, parentHash, blockHash, proposerPubkey, blockValue, nodeID string, ev GetPayloadFlowEvent) {
+}
+
+func (m *mockFlowService) GetAllFlowsSnapshot() map[string]*FlowRecord {
+	return nil
+}
+
+func (m *mockFlowService) GetFlowsBySlot(slot uint64) []*FlowRecord {
+	return nil
+}
+
+func (m *mockFlowService) GetFlowsBySlotAndBlock(slot uint64, blockHash string) []*FlowRecord {
+	return nil
+}
+
+// mockDataService is a mock of IDataService
+type mockDataService struct{}
+
+func (m *mockDataService) GetAccounts(ctx context.Context) map[string]any {
+	return nil
+}
+
+func (m *mockDataService) SetAccounts(ctx context.Context) {
+}
+
+func (m *mockDataService) SendAccount(accountID, validatorID string) {
+}
+
+func (m *mockDataService) GetDelaySettings(ctx context.Context) map[string]DelaySettings {
+	return nil
+}
+
+func (m *mockDataService) SetDelayForValidator(id string, delay, maxDelay int64) {
+}
+
+func (m *mockDataService) SetDelayForValidators(settings map[string]DelaySettings) {
+}
+
+func (m *mockDataService) DelayGetHeader(ctx context.Context, in DelayGetHeaderParams) (DelayGetHeaderResponse, error) {
+	return DelayGetHeaderResponse{}, nil
+}
+
+func (m *mockDataService) GetSlotDuty(slot uint64) (*common.MiniValidatorLatency, error) {
+	return nil, nil
+}
+
+func (m *mockDataService) GetFlowService() IFlowService {
+	return &mockFlowService{}
 }


### PR DESCRIPTION
## 📝 Summary

This one is instead of https://github.com/bloXroute-Labs/relayproxy/pull/85

Recording slot stats record only for 1st getpayload call. For this switched from `Set` to `Add` method of `go-cache`. Also did the renamings and added comments.

## 💡 Motivation and Context

This is to ensure we record correct slot stats focusing on shortest delay between getheader and getpayload and have less impact of Commit Boost retry logic.

---

## ✅ I have completed the following steps:

* [ ] Run `make lint`
* [ ] Run `make test`
* [ ] Run `go mod tidy`
* [ ] Added tests (if applicable)
