### PR TITLE
 MEV-1822: Add ping based delay

### DIFF
--- a/dataservice.go
+++ b/dataservice.go
@@ -117,13 +117,7 @@ type AccountsLists struct {
 	AccountIDToInfo   map[string]*AccountInfo
 	AccountNameToInfo map[AccountName]*AccountInfo
 }
-type DelayGetHeaderResponse struct {
-	Sleep, MaxSleep       int64
-	SlotStartTime         time.Time
-	Latency               int64
-	ExternalRelayResponse ExternalRelayResponse
-	ReplacementDelayMs    int64
-}
+
 type ExternalRelayResponse struct {
 	URL             string
 	ReqStartTime    time.Time
@@ -173,7 +167,7 @@ func (s *DataService) DelayGetHeader(ctx context.Context, in DelayGetHeaderParam
 	if GetHeaderRequestCutoffMs > 0 && msIntoSlot > GetHeaderRequestCutoffMs {
 		return DelayGetHeaderResponse{}, common.ErrLateHeader
 	}
-	sleep, maxSleep, replacementDelayMs, err = s.dynamicFuncWrapper(in.AccountID, msIntoSlot, in.Cluster, in.UserAgent, in.Latency, in.ClientIP, int64(in.headerTimeoutMS))
+	sleep, maxSleep, replacementDelayMs, err = s.dynamicFuncWrapper(in.AccountID, msIntoSlot, in.Cluster, in.UserAgent, in.Latency, in.ClientIP, int64(in.HeaderTimeoutMS))
 	if err != nil {
 		return DelayGetHeaderResponse{}, err
 	}

--- a/delayer.go
+++ b/delayer.go
@@ -1,0 +1,9 @@
+package relayproxy
+
+import (
+	"context"
+)
+
+type Delayer interface {
+	DelayGetHeader(ctx context.Context, in DelayGetHeaderParams) (DelayGetHeaderResponse, error)
+}

--- a/getheader.go
+++ b/getheader.go
@@ -21,13 +21,6 @@ import (
 	"github.com/bloXroute-Labs/relayproxy/fluentstats"
 )
 
-const (
-	figment  = "94955c54-8a85-4705-aec9-394ac89330b0"
-	kraken   = "196d352f-390c-4251-8525-8d4950dedf53"
-	coinbase = "cd42c659-6b5f-42f0-bbf2-0798879ccad0"
-	p2p      = "c6128441-e797-4f12-9ba1-23d66ecfa8b3"
-)
-
 func (s *Service) GetHeader(parentSpan trace.Span, parentCtx context.Context, log *zerolog.Logger, in *HeaderRequestParams) (json.RawMessage, *common.OnHeaderDeliveredParams, error) {
 	id := uuid.NewString()
 	ctx, span := s.tracer.Start(parentCtx, "getHeader-start")

--- a/getheader.go
+++ b/getheader.go
@@ -39,57 +39,42 @@ func (s *Service) GetHeader(parentSpan trace.Span, parentCtx context.Context, lo
 		delayGetHeaderResponse DelayGetHeaderResponse
 	)
 	delayCtx, delayGetHeaderSpan := s.tracer.Start(ctx, "getHeader-delayGetHeader")
-	if in.AccountID == figment || in.AccountID == kraken || in.AccountID == coinbase || in.AccountID == p2p {
-		delayGetHeaderResponse, err = s.delayer.DelayGetHeader(delayCtx, DelayGetHeaderParams{
-			ReceivedAt:          in.ReceivedAt,
-			Slot:                in.Slot,
-			AccountID:           in.AccountID,
-			Cluster:             in.Cluster,
-			UserAgent:           in.UserAgent,
-			ClientIP:            in.ClientIP,
-			SlotWithParentHash:  k,
-			BoostSendTimeUnixMS: in.GetHeaderStartTimeUnixMS,
-			Latency:             in.Latency,
-			HeaderTimeoutMS:     in.HeaderTimeoutMs, // client timeout
-		})
-		resp := delayGetHeaderResponse
+	delayGetHeaderResponse, err = s.delayer.DelayGetHeader(delayCtx, DelayGetHeaderParams{
+		ReceivedAt:          in.ReceivedAt,
+		Slot:                in.Slot,
+		AccountID:           in.AccountID,
+		Cluster:             in.Cluster,
+		UserAgent:           in.UserAgent,
+		ClientIP:            in.ClientIP,
+		SlotWithParentHash:  k,
+		BoostSendTimeUnixMS: in.GetHeaderStartTimeUnixMS,
+		Latency:             in.Latency,
+		HeaderTimeoutMS:     in.HeaderTimeoutMs, // client timeout
+	})
+	resp := delayGetHeaderResponse
 
-		*log = log.With().
-			// top-level response fields
-			Int64("sleep", resp.Sleep).
-			Int64("maxSleep", resp.MaxSleep).
-			Int64("replacementDelayMs", resp.ReplacementDelayMs).
-			Int64("latency", resp.Latency).
-			Time("slotStartTime", resp.SlotStartTime).
+	*log = log.With().
+		// top-level response fields
+		Int64("sleep", resp.Sleep).
+		Int64("maxSleep", resp.MaxSleep).
+		Int64("replacementDelayMs", resp.ReplacementDelayMs).
+		Int64("latency", resp.Latency).
+		Time("slotStartTime", resp.SlotStartTime).
 
-			// DelayInfo fields (exported)
-			Int64("slept", resp.DelayInfo.SleptMsActual).
-			Int64("sleepMsBefore", resp.DelayInfo.SleepMsBefore).
-			Int64("sleepMsAfter", resp.DelayInfo.SleepMsAfter).
-			Bool("isSleepUpdated", resp.DelayInfo.IsSleepUpdated).
-			Int64("oneWayMs", resp.DelayInfo.OneWayMs).
-			Int64("requestInitiatedAt", resp.DelayInfo.RequestInitiatedAt).
-			Int64("requestTimeout", resp.DelayInfo.RequestTimeout).
-			Time("requestDeadline", resp.DelayInfo.RequestDeadline).
-			Time("getHeaderDeadline", resp.DelayInfo.GetHeaderDeadline).
-			Time("effectiveDeadline", resp.DelayInfo.EffectiveDeadline).
-			Time("defaultWakeupAt", resp.DelayInfo.DefaultWakeupAt).
-			Time("updatedWakeupAt", resp.DelayInfo.UpdatedWakeupAt).
-			Logger()
-	} else {
-		delayGetHeaderResponse, err = s.IDataService.DelayGetHeader(delayCtx, DelayGetHeaderParams{
-			ReceivedAt:          in.ReceivedAt,
-			Slot:                in.Slot,
-			AccountID:           in.AccountID,
-			Cluster:             in.Cluster,
-			UserAgent:           in.UserAgent,
-			ClientIP:            in.ClientIP,
-			SlotWithParentHash:  k,
-			BoostSendTimeUnixMS: in.GetHeaderStartTimeUnixMS,
-			Latency:             in.Latency,
-			HeaderTimeoutMS:     in.HeaderTimeoutMs, // client timeout
-		})
-	}
+		// DelayInfo fields (exported)
+		Int64("slept", resp.DelayInfo.SleptMsActual).
+		Int64("sleepMsBefore", resp.DelayInfo.SleepMsBefore).
+		Int64("sleepMsAfter", resp.DelayInfo.SleepMsAfter).
+		Bool("isSleepUpdated", resp.DelayInfo.IsSleepUpdated).
+		Int64("oneWayMs", resp.DelayInfo.OneWayMs).
+		Int64("requestInitiatedAt", resp.DelayInfo.RequestInitiatedAt).
+		Int64("requestTimeout", resp.DelayInfo.RequestTimeout).
+		Time("requestDeadline", resp.DelayInfo.RequestDeadline).
+		Time("getHeaderDeadline", resp.DelayInfo.GetHeaderDeadline).
+		Time("effectiveDeadline", resp.DelayInfo.EffectiveDeadline).
+		Time("defaultWakeupAt", resp.DelayInfo.DefaultWakeupAt).
+		Time("updatedWakeupAt", resp.DelayInfo.UpdatedWakeupAt).
+		Logger()
 	delayGetHeaderSpan.End(trace.WithTimestamp(time.Now()))
 
 	_, preStoringHeaderSpan := s.tracer.Start(ctx, "getHeader-preStoringHeaderSpan")

--- a/getheader.go
+++ b/getheader.go
@@ -137,6 +137,31 @@ func (s *Service) GetHeader(parentSpan trace.Span, parentCtx context.Context, lo
 	originalValue := big.NewInt(0)
 	originalBlockHash := ""
 
+	// Repick algorithm (high level):
+	//  1) Initial fetch: GetTopBuilderBid(key) -> (best, second). This is the baseline header/value we would return.
+	//     - If best has a PayloadFetchUrl, we best-effort enqueue a prefetch.
+	//
+	//  2) Repick window: If ReplacementDelayMs > 0 and OnHeaderBidRetrieved is set,
+	//     we open a bounded "repick window" of length ReplacementDelayMs.
+	//     - Spawn a goroutine that calls OnHeaderBidRetrieved(repickCtx, currentBest, ...).
+	//     - repickCtx is capped by repickDeadline (hard deadline).
+	//     - Result is sent on a buffered channel (size 1) best-effort (never block).
+	//
+	//  3) Decide outcome (whichever happens first):
+	//     a) Receive repick result within window:
+	//        - If err: repick failed (record error), keep current best.
+	//        - If bid != nil: accept replacement bid (usedRepick=true), update best/value.
+	//        - If bid == nil: treat as failure, keep current best.
+	//     b) repickCtx deadline hits: timeout, keep current best.
+	//     c) request ctx canceled: abort repick, keep current best.
+	//
+	//  4) Final fetch (only if repick did NOT replace):
+	//     After the repick window closes, fetch GetTopBuilderBid(key) again.
+	//     If the newly fetched best has higher value than our current best, upgrade to it.
+	//     This might affect bid replacement.
+	//     (This is a final "catch-up" fetch; it does not wait beyond the repick deadline.)
+	//
+
 	if getErr == nil && slotBestHeader != nil {
 		originalValue = new(big.Int).SetBytes(slotBestHeader.Value)
 		blockValue = new(big.Int).Set(originalValue)
@@ -229,6 +254,8 @@ func (s *Service) GetHeader(parentSpan trace.Span, parentCtx context.Context, lo
 			case resCh <- r:
 			default:
 				// best-effort; should not block
+				log.Warn().
+					Msg("resCh full, dropping result (non-blocking send)")
 			}
 		}()
 

--- a/getheader.go
+++ b/getheader.go
@@ -21,27 +21,75 @@ import (
 	"github.com/bloXroute-Labs/relayproxy/fluentstats"
 )
 
+const (
+	figment  = "94955c54-8a85-4705-aec9-394ac89330b0"
+	kraken   = "196d352f-390c-4251-8525-8d4950dedf53"
+	coinbase = "cd42c659-6b5f-42f0-bbf2-0798879ccad0"
+	p2p      = "c6128441-e797-4f12-9ba1-23d66ecfa8b3"
+)
+
 func (s *Service) GetHeader(parentSpan trace.Span, parentCtx context.Context, log *zerolog.Logger, in *HeaderRequestParams) (json.RawMessage, *common.OnHeaderDeliveredParams, error) {
 	id := uuid.NewString()
 	ctx, span := s.tracer.Start(parentCtx, "getHeader-start")
 	defer span.End()
 
 	k := "slot-" + in.Slot + "-parentHash-" + in.ParentHash
-
+	var (
+		err                    error
+		delayGetHeaderResponse DelayGetHeaderResponse
+	)
 	delayCtx, delayGetHeaderSpan := s.tracer.Start(ctx, "getHeader-delayGetHeader")
+	if in.AccountID == figment || in.AccountID == kraken || in.AccountID == coinbase || in.AccountID == p2p {
+		delayGetHeaderResponse, err = s.delayer.DelayGetHeader(delayCtx, DelayGetHeaderParams{
+			ReceivedAt:          in.ReceivedAt,
+			Slot:                in.Slot,
+			AccountID:           in.AccountID,
+			Cluster:             in.Cluster,
+			UserAgent:           in.UserAgent,
+			ClientIP:            in.ClientIP,
+			SlotWithParentHash:  k,
+			BoostSendTimeUnixMS: in.GetHeaderStartTimeUnixMS,
+			Latency:             in.Latency,
+			HeaderTimeoutMS:     in.HeaderTimeoutMs, // client timeout
+		})
+		resp := delayGetHeaderResponse
 
-	delayGetHeaderResponse, err := s.DelayGetHeader(delayCtx, DelayGetHeaderParams{
-		ReceivedAt:          in.ReceivedAt,
-		Slot:                in.Slot,
-		AccountID:           in.AccountID,
-		Cluster:             in.Cluster,
-		UserAgent:           in.UserAgent,
-		ClientIP:            in.ClientIP,
-		SlotWithParentHash:  k,
-		BoostSendTimeUnixMS: in.GetHeaderStartTimeUnixMS,
-		Latency:             in.Latency,
-		headerTimeoutMS:     in.HeaderTimeoutMs, // client timeout
-	})
+		*log = log.With().
+			// top-level response fields
+			Int64("sleep", resp.Sleep).
+			Int64("maxSleep", resp.MaxSleep).
+			Int64("replacementDelayMs", resp.ReplacementDelayMs).
+			Int64("latency", resp.Latency).
+			Time("slotStartTime", resp.SlotStartTime).
+
+			// DelayInfo fields (exported)
+			Int64("slept", resp.DelayInfo.SleptMsActual).
+			Int64("sleepMsBefore", resp.DelayInfo.SleepMsBefore).
+			Int64("sleepMsAfter", resp.DelayInfo.SleepMsAfter).
+			Bool("isSleepUpdated", resp.DelayInfo.IsSleepUpdated).
+			Int64("oneWayMs", resp.DelayInfo.OneWayMs).
+			Int64("requestInitiatedAt", resp.DelayInfo.RequestInitiatedAt).
+			Int64("requestTimeout", resp.DelayInfo.RequestTimeout).
+			Time("requestDeadline", resp.DelayInfo.RequestDeadline).
+			Time("getHeaderDeadline", resp.DelayInfo.GetHeaderDeadline).
+			Time("effectiveDeadline", resp.DelayInfo.EffectiveDeadline).
+			Time("defaultWakeupAt", resp.DelayInfo.DefaultWakeupAt).
+			Time("updatedWakeupAt", resp.DelayInfo.UpdatedWakeupAt).
+			Logger()
+	} else {
+		delayGetHeaderResponse, err = s.IDataService.DelayGetHeader(delayCtx, DelayGetHeaderParams{
+			ReceivedAt:          in.ReceivedAt,
+			Slot:                in.Slot,
+			AccountID:           in.AccountID,
+			Cluster:             in.Cluster,
+			UserAgent:           in.UserAgent,
+			ClientIP:            in.ClientIP,
+			SlotWithParentHash:  k,
+			BoostSendTimeUnixMS: in.GetHeaderStartTimeUnixMS,
+			Latency:             in.Latency,
+			HeaderTimeoutMS:     in.HeaderTimeoutMs, // client timeout
+		})
+	}
 	delayGetHeaderSpan.End(trace.WithTimestamp(time.Now()))
 
 	_, preStoringHeaderSpan := s.tracer.Start(ctx, "getHeader-preStoringHeaderSpan")
@@ -77,6 +125,7 @@ func (s *Service) GetHeader(parentSpan trace.Span, parentCtx context.Context, lo
 	msIntoSlot := in.ReceivedAt.Sub(slotStartTime).Milliseconds() // without sleep and using received at
 	*log = log.With().
 		Int64("msIntoSlotIncludingDelay", msIntoSlotIncludingDelay).
+		Int64("receivedAtMsIntoSlot", msIntoSlot).
 		Logger()
 
 	preStoringHeaderSpan.End()
@@ -96,23 +145,31 @@ func (s *Service) GetHeader(parentSpan trace.Span, parentCtx context.Context, lo
 
 	fetchGetHeaderStartTime := time.Now().UTC()
 	keyForCachingBids := s.keyForCachingBids(_slot, in.ParentHash, in.PubKey)
+
+	initialBidFetchStart := time.Now().UTC()
 	slotBestHeader, secondBestHeader, getErr := s.GetTopBuilderBid(keyForCachingBids)
+	blockValue := new(big.Int)
+	initialFetchBidUsed := true
+	initialBidFetchDurationMs := time.Since(initialBidFetchStart).Milliseconds()
+
 	usedRepick := false
 	repickDataExist := false
 	repickDataSuccess := true
 	repickErr := ""
 	originalValue := big.NewInt(0)
 	originalBlockHash := ""
+
 	if getErr == nil && slotBestHeader != nil {
 		originalValue = new(big.Int).SetBytes(slotBestHeader.Value)
+		blockValue = new(big.Int).Set(originalValue)
 		originalBlockHash = slotBestHeader.BlockHash
 	} else {
 		log.Error().Err(getErr).Msg("error getting top builder bid")
 	}
 
-	// Send in an early prefetch payload request for Optimistic V3 block payloads
 	if slotBestHeader != nil && slotBestHeader.PayloadFetchUrl != "" {
-		s.preFetchPayloadChan <- preFetcherFields{
+		select {
+		case s.preFetchPayloadChan <- preFetcherFields{
 			clientIP:                          in.ClientIP,
 			authHeader:                        in.AuthHeader,
 			slot:                              _slot,
@@ -126,70 +183,155 @@ func (s *Service) GetHeader(parentSpan trace.Span, parentCtx context.Context, lo
 			slotStartTime:                     slotStartTime,
 			msIntoSlotGetHeaderIncludingDelay: msIntoSlotIncludingDelay,
 			getHeaderReqID:                    id,
+		}:
+		default:
+			log.Warn().Msg("prefetch channel full; skipping prefetch")
 		}
 	}
 
-	repickDurationMS := int64(0)
+	var (
+		repickStartTime time.Time
+		repickDeadline  time.Time
+		repickEndTime   time.Time
+		repickElapsedMs int64
+		repickOutcome   string // "replaced" | "nil" | "timeout" | "ctx_canceled" | "skipped"
 
-	repickTime := time.Now().Add(time.Duration(delayGetHeaderResponse.ReplacementDelayMs) * time.Millisecond)
-	replacementTime := repickTime.Add(-5 * time.Millisecond)
-	if delayGetHeaderResponse.ReplacementDelayMs > 0 {
-		replacementTimer := time.NewTimer(time.Until(replacementTime))
-		defer replacementTimer.Stop()
-		repickTimer := time.NewTimer(time.Until(repickTime))
-		defer repickTimer.Stop()
+		finalFetchAttempted   bool
+		finalFetchBidUsed     bool
+		finalFetchRemainingMs int64
+		finalFetchDurationMs  int64
+		repickDurationMs      int64 // duration of OnHeaderBidRetrieved
+	)
 
-		log.Info().Int64("replacementDelayMs", delayGetHeaderResponse.ReplacementDelayMs).Msg("waiting for replacement delay")
-		if getErr == nil && s.OnHeaderBidRetrieved != nil {
-			newBestHeaderCh := make(chan *common.Bid, 1)
-			go func() {
-				onHeaderBidRetrievedStart := time.Now()
-				onHeaderRetrievedCtx, onHeadonHeaderBidRetrievedSpan := s.tracer.Start(storingHeaderCtx, "getHeader-onHeaderBidRetrieved")
-				newBestHeader, replaceable, err := s.OnHeaderBidRetrieved(onHeaderRetrievedCtx, slotBestHeader, *log, _slot, in.ParentHash, slotBestHeader.BuilderPubkey, in.AccountID, delayGetHeaderResponse.ReplacementDelayMs, s.uniqueStreamingClients)
-				onHeadonHeaderBidRetrievedSpan.End()
-				repickDurationMS = time.Since(onHeaderBidRetrievedStart).Milliseconds()
-				log.Info().Bool("replaceable", replaceable).Int64("onHeaderBidRetrievedDuration", repickDurationMS).Msg("OnHeaderBidRetrieved duration")
-				repickDataExist = replaceable
-				if err != nil {
-					repickErr = err.Error()
-					log.Error().Err(err).Msg("OnHeaderBidRetrieved error")
-					newBestHeaderCh <- nil
-					return
-				}
-				newBestHeaderCh <- newBestHeader
-			}()
+	repickDelayMs := delayGetHeaderResponse.ReplacementDelayMs
+	bidAdjustmentStartAt := time.Now().UTC()
+
+	type repickResult struct {
+		bid         *common.Bid
+		replaceable bool
+		err         error
+		durationMs  int64
+	}
+
+	if repickDelayMs > 0 && getErr == nil && s.OnHeaderBidRetrieved != nil && slotBestHeader != nil {
+		repickStartTime = time.Now().UTC()
+		repickDeadline = repickStartTime.Add(time.Duration(repickDelayMs) * time.Millisecond)
+
+		// ctx that caps OnHeaderBidRetrieved to the repick window
+		repickCtx, cancel := context.WithDeadline(storingHeaderCtx, repickDeadline)
+		defer cancel()
+
+		resCh := make(chan repickResult, 1)
+
+		go func() {
+			start := time.Now()
+			onHeaderRetrievedCtx, span := s.tracer.Start(repickCtx, "getHeader-onHeaderBidRetrieved")
+			defer span.End()
+
+			newBestHeader, replaceable, err := s.OnHeaderBidRetrieved(
+				onHeaderRetrievedCtx,
+				slotBestHeader,
+				*log,
+				_slot,
+				in.ParentHash,
+				slotBestHeader.BuilderPubkey,
+				in.AccountID,
+				repickDelayMs,
+				s.uniqueStreamingClients,
+			)
+
+			r := repickResult{
+				bid:         newBestHeader,
+				replaceable: replaceable,
+				err:         err,
+				durationMs:  time.Since(start).Milliseconds(),
+			}
+
 			select {
-			case replacementHeader := <-newBestHeaderCh:
-				if replacementHeader != nil {
-					usedRepick = true
-					slotBestHeader = replacementHeader
-					getErr = nil
-					log.Info().Msg("got new bid after repick from channel")
-				} else {
-					log.Info().Msg("got nil bid after repick from channel")
-				}
-			case <-replacementTimer.C:
-				log.Error().Time("replacementTime", replacementTime).Time("repickTime", repickTime).Msg("OnHeaderBidRetrieved took too long, proceeding with the original bid")
-				repickErr = "timeout waiting for OnHeaderBidRetrieved"
+			case resCh <- r:
+			default:
+				// best-effort; should not block
+			}
+		}()
+
+		select {
+		case r := <-resCh:
+			repickDurationMs = r.durationMs
+			repickDataExist = r.replaceable
+
+			if r.err != nil {
+				repickErr = r.err.Error()
 				repickDataSuccess = false
-			}
-		}
-		if !usedRepick {
-			<-repickTimer.C
-			newBestHeader, secondBidHeader, err := s.GetTopBuilderBid(keyForCachingBids)
-			if err != nil {
-				log.Error().Err(err).Msg("error getting top builder bid after repick wait")
+				repickOutcome = r.err.Error()
+				log.Debug().Err(r.err).Msg("OnHeaderBidRetrieved error")
+			} else if r.bid != nil {
+				usedRepick = true
+				initialFetchBidUsed = false
+				blockValue = new(big.Int).SetBytes(r.bid.Value)
+				slotBestHeader = r.bid
+				getErr = nil
+				repickOutcome = "replaced"
+				log.Debug().Msg("got replacement bid within ReplacementDelayMs")
 			} else {
-				slotBestHeader = newBestHeader
-				secondBestHeader = secondBidHeader
-				getErr = err
-				log.Info().Msg("got new bid after repick wait")
+				repickDataSuccess = false
+				repickErr = "OnHeaderBidRetrieved returned nil"
+				repickOutcome = "nil"
+				log.Debug().Msg("repick returned nil bid")
 			}
+
+		case <-repickCtx.Done():
+			repickDataSuccess = false
+			repickErr = "timeout waiting for OnHeaderBidRetrieved"
+			repickOutcome = "timeout"
+			log.Debug().
+				Time("deadline", repickDeadline).
+				Int64("replacementDelayMs", repickDelayMs).
+				Msg("repick hard deadline reached")
+
+		case <-ctx.Done():
+			repickDataSuccess = false
+			repickErr = ctx.Err().Error()
+			repickOutcome = "ctx_canceled"
+			log.Debug().Err(ctx.Err()).Msg("request ctx canceled during repick")
 		}
+
+		if !usedRepick {
+			remaining := time.Until(repickDeadline)
+			finalFetchRemainingMs = remaining.Milliseconds()
+
+			finalFetchAttempted = true
+			fetchStart := time.Now().UTC()
+
+			newBestHeader, secondBidHeader, err := s.GetTopBuilderBid(keyForCachingBids)
+
+			if err != nil || newBestHeader == nil {
+				log.Debug().Err(err).Msg("error getting top builder bid after repick window")
+			} else {
+				newblockValue := new(big.Int).SetBytes(newBestHeader.Value)
+				if newblockValue.Cmp(blockValue) > 0 {
+					slotBestHeader = newBestHeader
+					secondBestHeader = secondBidHeader
+					getErr = err
+					blockValue = newblockValue
+					initialFetchBidUsed = false
+					finalFetchBidUsed = true
+				}
+			}
+			finalFetchDurationMs = time.Since(fetchStart).Milliseconds()
+		}
+
+		repickEndTime = time.Now().UTC()
+		repickElapsedMs = repickEndTime.Sub(repickStartTime).Milliseconds()
+
+	} else {
+		repickOutcome = "skipped"
+		repickDataSuccess = false
 	}
 
+	bidAdjustmentDurationMs := time.Since(bidAdjustmentStartAt).Milliseconds()
 	fetchGetHeaderDurationMS := time.Since(fetchGetHeaderStartTime).Milliseconds()
 	headerReqDuration := time.Since(in.ReceivedAt)
+
 	statsUserAgent := in.UserAgent
 	if in.Cluster != "" {
 		statsUserAgent += "/" + in.Cluster
@@ -227,6 +369,7 @@ func (s *Service) GetHeader(parentSpan trace.Span, parentCtx context.Context, lo
 		}()
 		return nil, nil, toErrorResp(http.StatusNoContent, "Header value is not present")
 	}
+
 	if slotBestHeader.AccountID != "" {
 		in.AccountID = slotBestHeader.AccountID
 		if s.accountsLists.AccountIDToInfo[in.AccountID] != nil &&
@@ -234,22 +377,46 @@ func (s *Service) GetHeader(parentSpan trace.Span, parentCtx context.Context, lo
 			in.ValidatorID = in.AccountID
 		}
 	}
-	blockValue := new(big.Int).SetBytes(slotBestHeader.Value)
 	_, signAndFinishSpan := s.tracer.Start(ctx, "getHeader-finalize")
 	defer signAndFinishSpan.End()
+
 	*log = log.With().
 		Str("blockHash", slotBestHeader.BlockHash).
 		Str("blockValue", blockValue.String()).
+
+		// overall timing
+		Int64("headerReqDurationMs", headerReqDuration.Milliseconds()).
+		Int64("fetchGetHeaderDurationMs", fetchGetHeaderDurationMS).
+		Int64("initialBidFetchDurationMs", initialBidFetchDurationMs).
+
+		// repick config + outcome
 		Int64("replacementDelayMs", delayGetHeaderResponse.ReplacementDelayMs).
 		Bool("usedRepick", usedRepick).
 		Bool("repickDataExist", repickDataExist).
 		Bool("repickDataSuccess", repickDataSuccess).
 		Str("repickErr", repickErr).
-		Int64("repickDurationMS", repickDurationMS).
+		Str("repickOutcome", repickOutcome).
+
+		// repick timings
+		Time("repickStartTime", repickStartTime).
+		Time("repickDeadline", repickDeadline).
+		Time("repickEndTime", repickEndTime).
+		Int64("repickElapsedMs", repickElapsedMs).
+		Int64("onHeaderBidRetrievedDurationMs", repickDurationMs).
+
+		// final fetch timings
+		Bool("finalFetchAttempted", finalFetchAttempted).
+		Int64("finalFetchRemainingMs", finalFetchRemainingMs).
+		Int64("finalFetchDurationMs", finalFetchDurationMs).
+		Bool("finalFetchBidUsed", finalFetchBidUsed).
+		Bool("initialFetchBidUsed", initialFetchBidUsed).
+
+		// original bid context
 		Int64("originalValue", originalValue.Int64()).
 		Str("originalBlockHash", originalBlockHash).
-		Time("replacementTime", replacementTime).
-		Time("repickTime", repickTime).
+
+		// your existing metric (renamed semantics: this is the whole repick flow, not only "adjustment")
+		Int64("bidAdjustmentDurationMs", bidAdjustmentDurationMs).
 		Logger()
 
 	go func() {
@@ -353,7 +520,7 @@ func (s *Service) GetHeader(parentSpan trace.Span, parentCtx context.Context, lo
 
 				OriginalValue:         originalValue.String(),
 				OriginalBlockHash:     originalBlockHash,
-				BidAdjustmentDuration: repickDurationMS,
+				BidAdjustmentDuration: bidAdjustmentDurationMs,
 				UsedAdjustment:        usedRepick,
 				AdjustmentDataExist:   repickDataExist,
 				AdjustmentDataSuccess: repickDataSuccess,

--- a/opts.go
+++ b/opts.go
@@ -340,6 +340,12 @@ func WithSvcPerformanceStats(performanceStats *stat.PerformanceStats) ServiceOpt
 	}
 }
 
+func WithDelayer(delayer Delayer) ServiceOption {
+	return func(s *Service) {
+		s.delayer = delayer
+	}
+}
+
 // ---------------- Data service options ----------------------
 
 type DataServiceOption func(s *DataService)

--- a/prefetch.go
+++ b/prefetch.go
@@ -134,7 +134,7 @@ func (s *Service) PreFetchGetPayload(ctx context.Context, fields preFetcherField
 		Str("blockHash", fields.blockHash).
 		Int64("msIntoSlotStart", msIntoSlotPrefetchStart).
 		Int64("msIntoSlotGetHeaderIncludingDelay", fields.msIntoSlotGetHeaderIncludingDelay).
-		Str("getHeaderReqID", fields.getHeaderReqID).
+		Str("getheaderReqID", fields.getHeaderReqID).
 		Str("builderPayloadFetchURL", fields.payloadFetchUrl).
 		Logger()
 	prefetchLogger.Info().Msg("received prefetchPayload")

--- a/server.go
+++ b/server.go
@@ -560,6 +560,7 @@ func (s *Server) HandleRegistration(w http.ResponseWriter, r *http.Request) {
 		Str("boostSendTime", boostSendTime).
 		Strs("headers", headers).
 		Int64("latency", latency).
+		Time("receivedAt", receivedAt).
 		Logger()
 
 	handleRegistrationSpan.SetAttributes(
@@ -576,12 +577,13 @@ func (s *Server) HandleRegistration(w http.ResponseWriter, r *http.Request) {
 		attribute.String("boostSendTime", boostSendTime),
 		attribute.Int64("latency", latency),
 		attribute.StringSlice("headers", headers),
+		attribute.Int64("receivedAt", receivedAt.UnixMilli()),
 	)
 	hasProposerMevProtect, err := GetProposerMevProtectQueryAny(parsedURL, &log)
 	if err != nil {
 		handleRegistrationSpan.SetStatus(codes.Error, err.Error())
 		log.Error().Err(err).Msg("could not parse proposer_mev_protect query parameter")
-		respondError(handleRegistrationCtx, handleRegistrationSpan, registration, w, toErrorResp(http.StatusInternalServerError, "could not parse boolean proposer_mev_protect"), &log, s.tracer)
+		respondError(handleRegistrationCtx, handleRegistrationSpan, registration, w, toErrorResp(http.StatusInternalServerError, "could not parse boolean proposer_mev_protect"), &log, s.tracer, receivedAt)
 		return
 	}
 	isSkipOptimism := false
@@ -591,7 +593,7 @@ func (s *Server) HandleRegistration(w http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			handleRegistrationSpan.SetStatus(codes.Error, err.Error())
 			log.Error().Err(err).Msg("could not parse skip_optimism query parameter")
-			respondError(handleRegistrationCtx, handleRegistrationSpan, registration, w, toErrorResp(http.StatusInternalServerError, "could not parse boolean skip_optimism: "+skipOptimismQuery), &log, s.tracer)
+			respondError(handleRegistrationCtx, handleRegistrationSpan, registration, w, toErrorResp(http.StatusInternalServerError, "could not parse boolean skip_optimism: "+skipOptimismQuery), &log, s.tracer, receivedAt)
 			return
 		}
 	}
@@ -602,7 +604,7 @@ func (s *Server) HandleRegistration(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		handleRegistrationSpan.SetStatus(codes.Error, err.Error())
 		log.Error().Err(err).Msg("could not read registration")
-		respondError(handleRegistrationCtx, handleRegistrationSpan, registration, w, toErrorResp(http.StatusInternalServerError, "could not read registration"), &log, s.tracer)
+		respondError(handleRegistrationCtx, handleRegistrationSpan, registration, w, toErrorResp(http.StatusInternalServerError, "could not read registration"), &log, s.tracer, receivedAt)
 		return
 	}
 	handleRegistrationSpan.AddEvent("handleRegistration- svcRegisterValidator")
@@ -628,7 +630,7 @@ func (s *Server) HandleRegistration(w http.ResponseWriter, r *http.Request) {
 		}
 	}()
 
-	if err := respondOK(handleRegistrationCtx, handleRegistrationSpan, registration, w, struct{}{}, &log, s.tracer, false); err == nil {
+	if err := respondOK(handleRegistrationCtx, handleRegistrationSpan, registration, w, struct{}{}, &log, s.tracer, false, receivedAt); err == nil {
 		success = true
 	}
 }
@@ -690,7 +692,7 @@ func (s *Server) HandleGetHeader(w http.ResponseWriter, r *http.Request) {
 			attribute.String("slotUID", headerSlotUID),
 			attribute.String("method", getHeader),
 			attribute.String("key", "slot-"+slot+"-parentHash-"+parentHash),
-			attribute.Int64("receivedAt", receivedAt.Unix()),
+			attribute.Int64("receivedAt", receivedAt.UnixMilli()),
 			attribute.String("slot", slot),
 			attribute.String("headerTimeoutStr", headerTimeoutStr),
 		)
@@ -735,6 +737,7 @@ func (s *Server) HandleGetHeader(w http.ResponseWriter, r *http.Request) {
 		Str("method", getHeader).
 		Str("key", "slot-"+slot+"-parentHash-"+parentHash).
 		Str("slot", slot).
+		Time("receivedAt", receivedAt).
 		Str("headerTimeoutStr", headerTimeoutStr).
 		Logger()
 
@@ -760,7 +763,7 @@ func (s *Server) HandleGetHeader(w http.ResponseWriter, r *http.Request) {
 		span.SetAttributes(
 			attribute.String("error", err.Error()),
 		)
-		respondError(handleGetHeaderCtx, span, getHeader, w, err, &log, s.tracer)
+		respondError(handleGetHeaderCtx, span, getHeader, w, err, &log, s.tracer, receivedAt)
 		return
 	}
 	go func() {
@@ -789,7 +792,7 @@ func (s *Server) HandleGetHeader(w http.ResponseWriter, r *http.Request) {
 
 	if !sszResponse {
 		log.Info().Msg("Responding with JSON")
-		if err := respondOK(handleGetHeaderCtx, span, getHeader, w, out, &log, s.tracer, true); err == nil {
+		if err := respondOK(handleGetHeaderCtx, span, getHeader, w, out, &log, s.tracer, true, receivedAt); err == nil {
 			success = true
 		}
 		return
@@ -798,14 +801,14 @@ func (s *Server) HandleGetHeader(w http.ResponseWriter, r *http.Request) {
 	versionedBid := new(common.VersionedSignedBuilderBid)
 	if err = versionedBid.UnmarshalJSON(out); err != nil {
 		log.Error().Err(err).Msg("Failed to unmarshal JSON")
-		respondError(handleGetHeaderCtx, span, getHeader, w, toErrorResp(http.StatusInternalServerError, err.Error()), &log, s.tracer)
+		respondError(handleGetHeaderCtx, span, getHeader, w, toErrorResp(http.StatusInternalServerError, err.Error()), &log, s.tracer, receivedAt)
 		return
 	}
 
 	sszMarshal, err := versionedBid.MarshalSSZ()
 	if err != nil {
 		log.Error().Err(err).Msg("Failed to marshal SSZ")
-		if err := respondOK(handleGetHeaderCtx, span, getHeader, w, out, &log, s.tracer, true); err == nil {
+		if err := respondOK(handleGetHeaderCtx, span, getHeader, w, out, &log, s.tracer, true, receivedAt); err == nil {
 			success = true
 		}
 		return
@@ -813,7 +816,7 @@ func (s *Server) HandleGetHeader(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set(common.HeaderEthConsensusVersion, versionedBid.Version.String())
 	log.Info().Msg("Responding with SSZ")
-	success = s.respondOKWithContextSSZMarshalled(handleGetHeaderCtx, span, getHeader, w, sszMarshal, &log, s.tracer)
+	success = s.respondOKWithContextSSZMarshalled(handleGetHeaderCtx, span, getHeader, w, sszMarshal, &log, s.tracer, receivedAt)
 }
 
 func (s *Server) HandleGetPayload(w http.ResponseWriter, r *http.Request) {
@@ -875,6 +878,7 @@ func (s *Server) HandleGetPayload(w http.ResponseWriter, r *http.Request) {
 		Strs("headers", headers).
 		Str("slotUID", headerSlotUID).
 		Str("headerTimeoutStr", headerTimeoutStr).
+		Time("receivedAt", receivedAt).
 		Logger()
 
 	span.SetAttributes(
@@ -897,13 +901,14 @@ func (s *Server) HandleGetPayload(w http.ResponseWriter, r *http.Request) {
 		attribute.StringSlice("headers", headers),
 		attribute.String("slotUID", headerSlotUID),
 		attribute.String("headerTimeoutStr", headerTimeoutStr),
+		attribute.Int64("receivedAt", receivedAt.UnixMilli()),
 	)
 
 	bodyBytes, err := io.ReadAll(r.Body)
 	if err != nil {
 		span.SetStatus(codes.Error, err.Error())
 		log.Error().Err(err).Time("currentTime", time.Now().UTC()).Msg("could not read registration")
-		respondError(getPayloadCtx, span, getPayload, w, toErrorResp(http.StatusInternalServerError, "could not read registration"), &log, s.tracer)
+		respondError(getPayloadCtx, span, getPayload, w, toErrorResp(http.StatusInternalServerError, "could not read registration"), &log, s.tracer, receivedAt)
 		return
 	}
 	signedBlindedBeaconBlock := new(common.VersionedSignedBlindedBeaconBlock)
@@ -916,7 +921,7 @@ func (s *Server) HandleGetPayload(w http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			log.Error().Err(err).Time("currentTime", time.Now().UTC()).Msg("failed to decode request payload")
 			decodeSSZSpan.End()
-			respondError(getPayloadCtx, span, getPayload, w, toErrorResp(http.StatusInternalServerError, "failed to decode request payload"), &log, s.tracer)
+			respondError(getPayloadCtx, span, getPayload, w, toErrorResp(http.StatusInternalServerError, "failed to decode request payload"), &log, s.tracer, receivedAt)
 			return
 		}
 		decodeSSZSpan.End()
@@ -928,7 +933,7 @@ func (s *Server) HandleGetPayload(w http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			encodeJSONSpan.End()
 			log.Error().Err(err).Time("currentTime", time.Now().UTC()).Msg("failed to marshal to json")
-			respondError(getPayloadCtx, span, getPayload, w, toErrorResp(http.StatusInternalServerError, "failed to marshal to json"), &log, s.tracer)
+			respondError(getPayloadCtx, span, getPayload, w, toErrorResp(http.StatusInternalServerError, "failed to marshal to json"), &log, s.tracer, receivedAt)
 			return
 		}
 		encodeJSONSpan.End()
@@ -963,7 +968,7 @@ func (s *Server) HandleGetPayload(w http.ResponseWriter, r *http.Request) {
 			attribute.String("error", err.Error()),
 		)
 		span.SetStatus(codes.Error, err.Error())
-		respondError(getPayloadCtx, span, method, w, err, &log, s.tracer)
+		respondError(getPayloadCtx, span, method, w, err, &log, s.tracer, receivedAt)
 		return
 	}
 	mergeLogMetric.End()
@@ -976,7 +981,7 @@ func (s *Server) HandleGetPayload(w http.ResponseWriter, r *http.Request) {
 		if fullPayloadResponse != nil {
 			w.Header().Set(common.HeaderEthConsensusVersion, fullPayloadResponse.Version.String())
 		}
-		success = s.respondOKWithContextSSZMarshalled(getPayloadCtx, span, method, w, versionedPayloadInfo.GetSszResponse(), &log, s.tracer)
+		success = s.respondOKWithContextSSZMarshalled(getPayloadCtx, span, method, w, versionedPayloadInfo.GetSszResponse(), &log, s.tracer, receivedAt)
 		writeResponseDuration := time.Since(writeResponseStart)
 		log = log.With().Dur("writeResponseDuration", writeResponseDuration).Logger()
 		return
@@ -996,7 +1001,7 @@ func (s *Server) HandleGetPayload(w http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			span.SetStatus(codes.Error, err.Error())
 			log.Error().Err(err).Time("currentTime", time.Now().UTC()).Msg("failed to unmarshal getPayload response from ssz")
-			respondError(getPayloadCtx, span, method, w, toErrorResp(http.StatusInternalServerError, err.Error()), &log, s.tracer)
+			respondError(getPayloadCtx, span, method, w, toErrorResp(http.StatusInternalServerError, err.Error()), &log, s.tracer, receivedAt)
 			return
 		}
 	}
@@ -1008,7 +1013,7 @@ func (s *Server) HandleGetPayload(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		log.Error().Err(err).Time("currentTime", time.Now().UTC()).Msg("failed to marshal getPayload response to json, responding with ssz")
 		span.SetStatus(codes.Error, err.Error())
-		success = s.respondOKWithContextSSZMarshalled(getPayloadCtx, span, method, w, versionedPayloadInfo.GetSszResponse(), &log, s.tracer)
+		success = s.respondOKWithContextSSZMarshalled(getPayloadCtx, span, method, w, versionedPayloadInfo.GetSszResponse(), &log, s.tracer, receivedAt)
 		return
 	}
 	marshalUnmarshalSpan.End()
@@ -1016,7 +1021,7 @@ func (s *Server) HandleGetPayload(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set(common.HeaderEthConsensusVersion, payloadResponse.Version.String())
 
 	writeResponseStart := time.Now().UTC()
-	if err := respondOK(getPayloadCtx, span, method, w, outByte, &log, s.tracer, true); err == nil {
+	if err := respondOK(getPayloadCtx, span, method, w, outByte, &log, s.tracer, true, receivedAt); err == nil {
 		success = true
 	}
 	writeResponseDuration := time.Since(writeResponseStart)
@@ -1077,6 +1082,7 @@ func (s *Server) HandleGetPayloadV2(w http.ResponseWriter, r *http.Request) {
 		Bool("sszResponse", sszResponse).
 		Strs("headers", headers).
 		Str("slotUID", headerSlotUID).
+		Time("receivedAt", receivedAt).
 		Logger()
 
 	span.SetAttributes(
@@ -1097,6 +1103,7 @@ func (s *Server) HandleGetPayloadV2(w http.ResponseWriter, r *http.Request) {
 		attribute.Bool("sszRequest", sszRequest),
 		attribute.Bool("sszResponse", sszResponse),
 		attribute.StringSlice("headers", headers),
+		attribute.Int64("receivedAt", receivedAt.UnixMilli()),
 		attribute.String("slotUID", headerSlotUID),
 	)
 
@@ -1104,7 +1111,7 @@ func (s *Server) HandleGetPayloadV2(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		span.SetStatus(codes.Error, err.Error())
 		log.Error().Err(err).Time("currentTime", time.Now().UTC()).Msg("could not read registration")
-		respondError(getPayloadCtx, span, getPayloadV2, w, toErrorResp(http.StatusInternalServerError, "could not read payload"), &log, s.tracer)
+		respondError(getPayloadCtx, span, getPayloadV2, w, toErrorResp(http.StatusInternalServerError, "could not read payload"), &log, s.tracer, receivedAt)
 		return
 	}
 	signedBlindedBeaconBlock := new(common.VersionedSignedBlindedBeaconBlock)
@@ -1117,7 +1124,7 @@ func (s *Server) HandleGetPayloadV2(w http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			log.Error().Err(err).Time("currentTime", time.Now().UTC()).Msg("failed to decode request payload")
 			decodeSSZSpan.End()
-			respondError(getPayloadCtx, span, getPayloadV2, w, toErrorResp(http.StatusInternalServerError, "failed to decode request payload"), &log, s.tracer)
+			respondError(getPayloadCtx, span, getPayloadV2, w, toErrorResp(http.StatusInternalServerError, "failed to decode request payload"), &log, s.tracer, receivedAt)
 			return
 		}
 		decodeSSZSpan.End()
@@ -1129,7 +1136,7 @@ func (s *Server) HandleGetPayloadV2(w http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			encodeJSONSpan.End()
 			log.Error().Err(err).Time("currentTime", time.Now().UTC()).Msg("failed to marshal to json")
-			respondError(getPayloadCtx, span, getPayloadV2, w, toErrorResp(http.StatusInternalServerError, "failed to marshal to json"), &log, s.tracer)
+			respondError(getPayloadCtx, span, getPayloadV2, w, toErrorResp(http.StatusInternalServerError, "failed to marshal to json"), &log, s.tracer, receivedAt)
 			return
 		}
 		encodeJSONSpan.End()
@@ -1160,7 +1167,7 @@ func (s *Server) HandleGetPayloadV2(w http.ResponseWriter, r *http.Request) {
 			Msg("Error in GetPayloadV2")
 		span.SetAttributes(attribute.String("error", err.Error()))
 		span.SetStatus(codes.Error, err.Error())
-		respondError(getPayloadCtx, span, method, w, err, &log, s.tracer)
+		respondError(getPayloadCtx, span, method, w, err, &log, s.tracer, receivedAt)
 		return
 	}
 	// need to confirm eth consensusVersion
@@ -1174,13 +1181,13 @@ func respondStatusAccepted(ctx context.Context, parentSpan trace.Span, method st
 	parentSpan.SetAttributes(
 		attribute.Int("responseCode", http.StatusAccepted),
 	)
-	log.Info().Str("method", method).Msg(method + " succeeded")
+	log.Info().Time("respondedAt", time.Now().UTC()).Str("method", method).Msg(method + " succeeded")
 	w.Header().Set(common.HeaderContentType, common.MediaTypeJSON)
 	w.WriteHeader(http.StatusAccepted)
 	return true
 }
 
-func respondOK(ctx context.Context, parentSpan trace.Span, method string, w http.ResponseWriter, response any, log *zerolog.Logger, tracer trace.Tracer, logMessage bool) error {
+func respondOK(ctx context.Context, parentSpan trace.Span, method string, w http.ResponseWriter, response any, log *zerolog.Logger, tracer trace.Tracer, logMessage bool, receivedAt time.Time) error {
 	_, span := tracer.Start(ctx, "respondOK-"+method)
 	defer span.End()
 	parentSpan.SetAttributes(
@@ -1196,12 +1203,15 @@ func respondOK(ctx context.Context, parentSpan trace.Span, method string, w http
 		return err
 	}
 	if logMessage {
-		log.Info().Str("method", method).Msg(method + " succeeded")
+		log.Info().
+			Int64("totalReqDurationMs", time.Since(receivedAt).Milliseconds()).
+			Time("respondedAt", time.Now().UTC()).
+			Str("method", method).Msg(method + " succeeded")
 	}
 	return nil
 }
 
-func respondError(ctx context.Context, parentSpan trace.Span, method string, w http.ResponseWriter, err error, log *zerolog.Logger, tracer trace.Tracer) {
+func respondError(ctx context.Context, parentSpan trace.Span, method string, w http.ResponseWriter, err error, log *zerolog.Logger, tracer trace.Tracer, receivedAt time.Time) {
 
 	_, span := tracer.Start(ctx, "respondError-"+method)
 	defer span.End()
@@ -1236,7 +1246,12 @@ func respondError(ctx context.Context, parentSpan trace.Span, method string, w h
 		attribute.Int("responseCode", resp.ErrorCode()),
 	)
 	w.WriteHeader(resp.Code)
-	log.Error().Str("method", method).Msg(method + " failed")
+
+	log.Error().
+		Int64("totalReqDurationMs", time.Since(receivedAt).Milliseconds()).
+		Time("respondedAt", time.Now().UTC()).
+		Str("method", method).Msg(method + " failed")
+
 	if resp.Message != "" && resp.Code != http.StatusNoContent { // HTTP status "No Content" implies that no message body should be included in the response.
 		if err := json.NewEncoder(w).Encode(resp); err != nil {
 			span.SetStatus(codes.Error, "couldn't write error response")
@@ -1283,7 +1298,7 @@ func parseQuery(query string, value string, log *zerolog.Logger) (bool, error) {
 	return proposerMevProtect, err
 }
 
-func (s *Server) respondOKWithContextSSZMarshalled(ctx context.Context, parentSpan trace.Span, method string, w http.ResponseWriter, resBytes []byte, log *zerolog.Logger, tracer trace.Tracer) bool {
+func (s *Server) respondOKWithContextSSZMarshalled(ctx context.Context, parentSpan trace.Span, method string, w http.ResponseWriter, resBytes []byte, log *zerolog.Logger, tracer trace.Tracer, receivedAt time.Time) bool {
 	_, span := tracer.Start(ctx, fmt.Sprintf("respondOKSSZ-%s", method))
 	defer span.End()
 	parentSpan.SetAttributes(
@@ -1305,6 +1320,10 @@ func (s *Server) respondOKWithContextSSZMarshalled(ctx context.Context, parentSp
 		http.Error(w, "", http.StatusInternalServerError)
 		return false
 	}
-	log.Info().Str("method", method).Msg(method + " succeeded")
+
+	log.Info().
+		Int64("totalReqDurationMs", time.Since(receivedAt).Milliseconds()).
+		Time("respondedAt", time.Now().UTC()).
+		Str("method", method).Msg(method + " succeeded")
 	return true
 }

--- a/service.go
+++ b/service.go
@@ -123,6 +123,8 @@ type Service struct {
 	BlockPublishFunc             func(tracer trace.Tracer, logger zerolog.Logger, payloadInfo *common.VersionedPayloadInfo, signedBeaconBlock *common.VersionedSignedBlindedBeaconBlock, blockPublishingGatewayClient interface{}, authKey string)
 	OnPayloadRequested           func(slot uint64, blockHash string, parentHash string, proposerPubkey string, getPayloadRequestClientIP string, receivedAt time.Time, signedBlindedBeaconBlock *eth2Api.VersionedSignedBlindedBeaconBlock, ProposerRequestStartTimeUnixMS int64, validatorID string) error
 	OnHeaderBidRetrieved         func(ctx context.Context, bid *common.Bid, log zerolog.Logger, slot uint64, parentHash, builderPubkey, accountID string, replacemendDelayMs int64, clients []*common.ParentClient) (*common.Bid, bool, error)
+
+	delayer Delayer
 }
 
 type slotStatsEvent struct {

--- a/types.go
+++ b/types.go
@@ -90,5 +90,29 @@ type DelayGetHeaderParams struct {
 	SlotWithParentHash  string
 	BoostSendTimeUnixMS string
 	Latency             int64
-	headerTimeoutMS     uint64 // client timeout
+	HeaderTimeoutMS     uint64 // client timeout
+}
+
+type DelayGetHeaderResponse struct {
+	Sleep, MaxSleep       int64
+	SlotStartTime         time.Time
+	Latency               int64
+	ExternalRelayResponse ExternalRelayResponse
+	ReplacementDelayMs    int64
+	DelayInfo             DelayInfo
+}
+
+type DelayInfo struct {
+	IsSleepUpdated     bool
+	SleepMsBefore      int64
+	SleepMsAfter       int64
+	SleptMsActual      int64
+	OneWayMs           int64 // one way ping ms which rtt/2
+	RequestInitiatedAt int64
+	RequestTimeout     int64
+	RequestDeadline    time.Time
+	GetHeaderDeadline  time.Time // default getHeader window 2.9secs
+	EffectiveDeadline  time.Time
+	DefaultWakeupAt    time.Time
+	UpdatedWakeupAt    time.Time
 }


### PR DESCRIPTION
## 📝 Summary

<!--- A general summary of your changes -->
- Replace fixed latency-based delays with a ping-based dynamic delay calculation.
- Start scheduling immediately using a safe default delay and update it if a ping result becomes available.
- Ensure request timing respects both the request timeout and the validator getHeader timeout window.

## 💡 Motivation and Context

<!--- (Optional) Why is this change required? What problem does it solve? Remove this section if not applicable. -->
Previously, delay logic relied on static or calcualted latency, which could be inaccurate or stale.
This change introduces  ping based oneway network delay and dynamically adjust wakeup timing. The approach remains safe by falling back to defaults when ping data is unavailable and by enforcing strict timeout caps, improving timing accuracy without adding risk or complexity.
---

## ✅ I have completed the following steps:

* [x] Run `make lint`
* [x] Run `make test`
* [x] Run `go mod tidy`
* [ ] Added tests (if applicable)
