### PR TITLE
MEV-1809/RelayProxy-send-bid-adjustment-data-in-SubmitBlockV3-and-StreamheaderResponse

### DIFF
--- a/common/types.go
+++ b/common/types.go
@@ -437,7 +437,7 @@ type Bid struct {
 	AuthHeader          string
 	BlockSequenceNumber *uint64
 	Hidden              bool
-	SszAdjustmentData   []byte // TODO: might be better to switch to VersionedAdjustmentData instead of []byte?
+	AdjustmentData      *bidadjustment.VersionedAdjustmentData
 }
 
 func NewBid(Value []byte,
@@ -453,7 +453,7 @@ func NewBid(Value []byte,
 	authHeader string,
 	blockSequenceNumber *uint64,
 	hidden bool,
-	sszAdjustmentData []byte,
+	adjustmentData *bidadjustment.VersionedAdjustmentData,
 ) *Bid {
 	return &Bid{
 		Value:               Value,
@@ -469,7 +469,7 @@ func NewBid(Value []byte,
 		AuthHeader:          authHeader,
 		BlockSequenceNumber: blockSequenceNumber,
 		Hidden:              hidden,
-		SszAdjustmentData:   sszAdjustmentData,
+		AdjustmentData:      adjustmentData,
 	}
 }
 

--- a/common/types.go
+++ b/common/types.go
@@ -437,6 +437,7 @@ type Bid struct {
 	AuthHeader          string
 	BlockSequenceNumber *uint64
 	Hidden              bool
+	SszAdjustmentData   []byte // TODO: might be better to switch to VersionedAdjustmentData instead of []byte?
 }
 
 func NewBid(Value []byte,
@@ -452,6 +453,7 @@ func NewBid(Value []byte,
 	authHeader string,
 	blockSequenceNumber *uint64,
 	hidden bool,
+	sszAdjustmentData []byte,
 ) *Bid {
 	return &Bid{
 		Value:               Value,
@@ -467,6 +469,7 @@ func NewBid(Value []byte,
 		AuthHeader:          authHeader,
 		BlockSequenceNumber: blockSequenceNumber,
 		Hidden:              hidden,
+		SszAdjustmentData:   sszAdjustmentData,
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.2
 require (
 	github.com/attestantio/go-builder-client v0.7.2
 	github.com/attestantio/go-eth2-client v0.27.1
-	github.com/bloXroute-Labs/relay-grpc v0.0.71
+	github.com/bloXroute-Labs/relay-grpc v0.0.72-0.20260310140433-c1964ffc651b
 	github.com/ethereum/go-ethereum v1.16.3
 	github.com/ferranbt/fastssz v1.0.0
 	github.com/flashbots/go-boost-utils v1.9.0

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.2
 require (
 	github.com/attestantio/go-builder-client v0.7.2
 	github.com/attestantio/go-eth2-client v0.27.1
-	github.com/bloXroute-Labs/relay-grpc v0.0.72-0.20260310140433-c1964ffc651b
+	github.com/bloXroute-Labs/relay-grpc v0.0.72-0.20260310160835-4e62eb04ef6e
 	github.com/ethereum/go-ethereum v1.16.3
 	github.com/ferranbt/fastssz v1.0.0
 	github.com/flashbots/go-boost-utils v1.9.0

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.2
 require (
 	github.com/attestantio/go-builder-client v0.7.2
 	github.com/attestantio/go-eth2-client v0.27.1
-	github.com/bloXroute-Labs/relay-grpc v0.0.72-0.20260310160835-4e62eb04ef6e
+	github.com/bloXroute-Labs/relay-grpc v0.0.72
 	github.com/ethereum/go-ethereum v1.16.3
 	github.com/ferranbt/fastssz v1.0.0
 	github.com/flashbots/go-boost-utils v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/attestantio/go-eth2-client v0.27.1 h1:g7bm+gG/p+gfzYdEuxuAepVWYb8EO+2
 github.com/attestantio/go-eth2-client v0.27.1/go.mod h1:fvULSL9WtNskkOB4i+Yyr6BKpNHXvmpGZj9969fCrfY=
 github.com/bits-and-blooms/bitset v1.20.0 h1:2F+rfL86jE2d/bmw7OhqUg2Sj/1rURkBn3MdfoPyRVU=
 github.com/bits-and-blooms/bitset v1.20.0/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
-github.com/bloXroute-Labs/relay-grpc v0.0.71 h1:LAChynH3N/elae+0nhSaN4bUT0eqjZ11doQ4PLS2Kew=
-github.com/bloXroute-Labs/relay-grpc v0.0.71/go.mod h1:U/KsWYeCWdBiJU2781Cu/Kqq6ok3hr/LbMRZ1pheKuQ=
+github.com/bloXroute-Labs/relay-grpc v0.0.72-0.20260310140433-c1964ffc651b h1:L/3HAPEVL4YT9kKmDY8qzRVOWSflgYKEtFRA9SfhZBI=
+github.com/bloXroute-Labs/relay-grpc v0.0.72-0.20260310140433-c1964ffc651b/go.mod h1:U/KsWYeCWdBiJU2781Cu/Kqq6ok3hr/LbMRZ1pheKuQ=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
 github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/attestantio/go-eth2-client v0.27.1 h1:g7bm+gG/p+gfzYdEuxuAepVWYb8EO+2
 github.com/attestantio/go-eth2-client v0.27.1/go.mod h1:fvULSL9WtNskkOB4i+Yyr6BKpNHXvmpGZj9969fCrfY=
 github.com/bits-and-blooms/bitset v1.20.0 h1:2F+rfL86jE2d/bmw7OhqUg2Sj/1rURkBn3MdfoPyRVU=
 github.com/bits-and-blooms/bitset v1.20.0/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
-github.com/bloXroute-Labs/relay-grpc v0.0.72-0.20260310140433-c1964ffc651b h1:L/3HAPEVL4YT9kKmDY8qzRVOWSflgYKEtFRA9SfhZBI=
-github.com/bloXroute-Labs/relay-grpc v0.0.72-0.20260310140433-c1964ffc651b/go.mod h1:U/KsWYeCWdBiJU2781Cu/Kqq6ok3hr/LbMRZ1pheKuQ=
+github.com/bloXroute-Labs/relay-grpc v0.0.72-0.20260310160835-4e62eb04ef6e h1:uo2by0MnRd4T6Clkh48R5rA4mwSenB0DTeatAWd92z8=
+github.com/bloXroute-Labs/relay-grpc v0.0.72-0.20260310160835-4e62eb04ef6e/go.mod h1:U/KsWYeCWdBiJU2781Cu/Kqq6ok3hr/LbMRZ1pheKuQ=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
 github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/attestantio/go-eth2-client v0.27.1 h1:g7bm+gG/p+gfzYdEuxuAepVWYb8EO+2
 github.com/attestantio/go-eth2-client v0.27.1/go.mod h1:fvULSL9WtNskkOB4i+Yyr6BKpNHXvmpGZj9969fCrfY=
 github.com/bits-and-blooms/bitset v1.20.0 h1:2F+rfL86jE2d/bmw7OhqUg2Sj/1rURkBn3MdfoPyRVU=
 github.com/bits-and-blooms/bitset v1.20.0/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
-github.com/bloXroute-Labs/relay-grpc v0.0.72-0.20260310160835-4e62eb04ef6e h1:uo2by0MnRd4T6Clkh48R5rA4mwSenB0DTeatAWd92z8=
-github.com/bloXroute-Labs/relay-grpc v0.0.72-0.20260310160835-4e62eb04ef6e/go.mod h1:U/KsWYeCWdBiJU2781Cu/Kqq6ok3hr/LbMRZ1pheKuQ=
+github.com/bloXroute-Labs/relay-grpc v0.0.72 h1:YWf0D660lvXhMCyRztCEIkF3npEJGxDDdQyyuQkJy/4=
+github.com/bloXroute-Labs/relay-grpc v0.0.72/go.mod h1:U/KsWYeCWdBiJU2781Cu/Kqq6ok3hr/LbMRZ1pheKuQ=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
 github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=

--- a/service.go
+++ b/service.go
@@ -370,22 +370,44 @@ func (s *Service) StreamHeader(ctx context.Context, client *common.Client, paren
 		keyForCachingBids := s.keyForCachingBids(header.GetSlot(), header.GetParentHash(), header.GetPubkey())
 		uniqueKey := fmt.Sprintf("slot_%v_bHash_%v_pHash_%v", header.GetSlot(), header.GetBlockHash(), header.GetParentHash())
 
+		// Unmarshal bid adjustment data if necessary
+		var adjustmentData *bidadjustment.VersionedAdjustmentData
+		sszAdjustmentData := header.GetSszAdjustmentData()
+		if sszAdjustmentData != nil {
+			versionedAdjustmentData := new(bidadjustment.VersionedAdjustmentData)
+			if err = versionedAdjustmentData.UnmarshalSSZ(sszAdjustmentData); err != nil {
+				s.logger.Error().Err(err).Fields(logMetric.GetFields()).Msg("failed to unmarshal bid adjustment data")
+			} else {
+				// Successful unmarshal
+				adjustmentData = versionedAdjustmentData
+			}
+		}
+
+		adjustmentDataVersion := bidadjustment.AdjustmentDataVersionUnknown
+		adjustmentDataExists := adjustmentData != nil
+		if adjustmentDataExists {
+			adjustmentDataVersion = adjustmentData.Version
+		}
+
 		lm.Fields(map[string]any{
-			"keyForCachingBids":   keyForCachingBids,
-			"slot":                header.GetSlot(),
-			"in.ParentHash":       header.GetParentHash(),
-			"blockHash":           header.GetBlockHash(),
-			"pubKey":              header.GetPubkey(),
-			"builderPubKey":       header.GetBuilderPubkey(),
-			"extraData":           header.GetBuilderExtraData(),
-			"traceID":             parentSpan.SpanContext().TraceID().String(),
-			"uniqueKey":           uniqueKey,
-			"receivedAt":          receivedAt,
-			"paidBlxr":            header.GetPaidBlxr(),
-			"accountID":           header.GetAccountId(),
-			"payloadFetchUrl":     header.GetPayloadFetchUrl(),
-			"blockSequenceNumber": header.GetBlockSequenceNumber(),
-			"hidden":              header.GetHidden(),
+			"keyForCachingBids":        keyForCachingBids,
+			"slot":                     header.GetSlot(),
+			"in.ParentHash":            header.GetParentHash(),
+			"blockHash":                header.GetBlockHash(),
+			"pubKey":                   header.GetPubkey(),
+			"builderPubKey":            header.GetBuilderPubkey(),
+			"extraData":                header.GetBuilderExtraData(),
+			"traceID":                  parentSpan.SpanContext().TraceID().String(),
+			"uniqueKey":                uniqueKey,
+			"receivedAt":               receivedAt,
+			"paidBlxr":                 header.GetPaidBlxr(),
+			"accountID":                header.GetAccountId(),
+			"payloadFetchUrl":          header.GetPayloadFetchUrl(),
+			"hidden":                   header.GetHidden(),
+			"blockSequenceNumber":      header.GetBlockSequenceNumber(),
+			"originalSubmissionMethod": header.GetOriginalSubmissionMethod(),
+			"adjustmentDataExists":     adjustmentDataExists,
+			"adjustmentDataVersion":    adjustmentDataVersion,
 		})
 
 		getPayloadOnly := false
@@ -468,19 +490,6 @@ func (s *Service) StreamHeader(ctx context.Context, client *common.Client, paren
 			continue
 		}
 
-		// Unmarshal bid adjustment data if necessary
-		var adjustmentData *bidadjustment.VersionedAdjustmentData
-		sszAdjustmentData := header.GetSszAdjustmentData()
-		if sszAdjustmentData != nil {
-			versionedAdjustmentData := new(bidadjustment.VersionedAdjustmentData)
-			if err = versionedAdjustmentData.UnmarshalSSZ(sszAdjustmentData); err != nil {
-				s.logger.Error().Err(err).Fields(logMetric.GetFields()).Msg("failed to unmarshal bid adjustment data")
-			} else {
-				// Successful unmarshal
-				adjustmentData = versionedAdjustmentData
-			}
-		}
-
 		bid := common.NewBid(
 			header.GetValue(),
 			header.GetPayload(),
@@ -501,12 +510,6 @@ func (s *Service) StreamHeader(ctx context.Context, client *common.Client, paren
 		if !getPayloadOnly {
 			s.setBuilderBidForProxySlot(keyForCachingBids, header.GetBuilderPubkey(), bid, header.GetSlot())
 			s.allBidsMetadataForProxySlot.SetBidMetadataForProxySlot(&s.logger, keyForCachingBids, bid)
-		}
-
-		adjustmentDataVersion := bidadjustment.AdjustmentDataVersionUnknown
-		adjustmentDataExists := adjustmentData != nil
-		if adjustmentDataExists {
-			adjustmentDataVersion = adjustmentData.Version
 		}
 
 		storeBidsSpan.SetAttributes(
@@ -532,6 +535,7 @@ func (s *Service) StreamHeader(ctx context.Context, client *common.Client, paren
 			attribute.String("accountID", header.GetAccountId()),
 			attribute.String("payloadFetchUrl", header.GetPayloadFetchUrl()),
 			attribute.Bool("hidden", header.GetHidden()),
+			attribute.String("originalSubmissionMethod", header.GetOriginalSubmissionMethod()),
 			attribute.Int64("blockSequenceNumber", int64(header.GetBlockSequenceNumber())),
 			attribute.Bool("adjustmentDataExists", adjustmentDataExists),
 			attribute.Int64("adjustmentDataVersion", int64(adjustmentDataVersion)),

--- a/service.go
+++ b/service.go
@@ -17,6 +17,7 @@ import (
 	"github.com/attestantio/go-eth2-client/spec/bellatrix"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	relaygrpc "github.com/bloXroute-Labs/relay-grpc"
+	"github.com/bloXroute-Labs/relay-grpc/bidadjustment"
 	"github.com/bloXroute-Labs/relay-grpc/optimisticv3"
 	"github.com/bloXroute-Labs/relay-grpc/stat"
 	"github.com/bloXroute-Labs/relayproxy/common"
@@ -465,6 +466,20 @@ func (s *Service) StreamHeader(ctx context.Context, client *common.Client, paren
 			s.logger.Error().Fields(logMetric.GetFields()).Msg("failed to convert to versioned header submission")
 			continue
 		}
+
+		// Unmarshal bid adjustment data if necessary
+		var adjustmentData *bidadjustment.VersionedAdjustmentData
+		sszAdjustmentData := header.GetSszAdjustmentData()
+		if sszAdjustmentData != nil {
+			versionedAdjustmentData := new(bidadjustment.VersionedAdjustmentData)
+			if err = versionedAdjustmentData.UnmarshalSSZ(sszAdjustmentData); err != nil {
+				s.logger.Error().Err(err).Fields(logMetric.GetFields()).Msg("failed to unmarshal bid adjustment data")
+			} else {
+				// Successful unmarshal
+				adjustmentData = versionedAdjustmentData
+			}
+		}
+
 		bid := common.NewBid(
 			header.GetValue(),
 			header.GetPayload(),
@@ -479,11 +494,17 @@ func (s *Service) StreamHeader(ctx context.Context, client *common.Client, paren
 			"",
 			blockSequenceNumber,
 			header.GetHidden(),
-			header.GetSszAdjustmentData(),
+			adjustmentData,
 		)
 
 		s.setBuilderBidForProxySlot(keyForCachingBids, header.GetBuilderPubkey(), bid, header.GetSlot())
 		s.allBidsMetadataForProxySlot.SetBidMetadataForProxySlot(&s.logger, keyForCachingBids, bid)
+
+		adjustmentDataVersion := bidadjustment.AdjustmentDataVersionUnknown
+		adjustmentDataExists := adjustmentData != nil
+		if adjustmentDataExists {
+			adjustmentDataVersion = adjustmentData.Version
+		}
 
 		storeBidsSpan.SetAttributes(
 			attribute.String("method", method),
@@ -494,7 +515,6 @@ func (s *Service) StreamHeader(ctx context.Context, client *common.Client, paren
 			attribute.String("relayReceiveAt", header.GetRelayReceiveTime().AsTime().String()),
 			attribute.String("streamSentAt", header.GetSendTime().AsTime().String()),
 			attribute.Int64("streamLatencyInMs", latency),
-
 			attribute.String("keyForCachingBids", keyForCachingBids),
 			attribute.Int64("slot", int64(header.GetSlot())),
 			attribute.String("in.ParentHash", header.GetParentHash()),
@@ -509,7 +529,11 @@ func (s *Service) StreamHeader(ctx context.Context, client *common.Client, paren
 			attribute.String("accountID", header.GetAccountId()),
 			attribute.String("payloadFetchUrl", header.GetPayloadFetchUrl()),
 			attribute.Bool("hidden", header.GetHidden()),
+			attribute.Int64("blockSequenceNumber", int64(header.GetBlockSequenceNumber())),
+			attribute.Bool("adjustmentDataExists", adjustmentDataExists),
+			attribute.Int64("adjustmentDataVersion", int64(adjustmentDataVersion)),
 		)
+
 		if duplicateReceiveTime > 0 {
 			storeBidsSpan.SetAttributes(
 				attribute.String("blockHash", header.GetBlockHash()),

--- a/service.go
+++ b/service.go
@@ -479,6 +479,7 @@ func (s *Service) StreamHeader(ctx context.Context, client *common.Client, paren
 			"",
 			blockSequenceNumber,
 			header.GetHidden(),
+			header.GetSszAdjustmentData(),
 		)
 
 		s.setBuilderBidForProxySlot(keyForCachingBids, header.GetBuilderPubkey(), bid, header.GetSlot())

--- a/service_test.go
+++ b/service_test.go
@@ -347,6 +347,7 @@ func TestBlockCancellation(t *testing.T) {
 		"",
 		nil,
 		false,
+		nil,
 	)
 	bidsMap.Store(testBuilderPubkey1, lowBid)
 
@@ -365,6 +366,7 @@ func TestBlockCancellation(t *testing.T) {
 		"",
 		nil,
 		false,
+		nil,
 	)
 	bidsMap.Store(testBuilderPubkey2, highBid)
 
@@ -383,6 +385,7 @@ func TestBlockCancellation(t *testing.T) {
 		"",
 		nil,
 		false,
+		nil,
 	)
 	bidsMap.Store(testBuilderPubkey3, mediumBid)
 
@@ -429,6 +432,7 @@ func TestBlockCancellationForSamePubKey(t *testing.T) {
 		"",
 		nil,
 		false,
+		nil,
 	)
 	bidsMap.Store(testBuilderPubkey1, lowBid)
 
@@ -447,6 +451,7 @@ func TestBlockCancellationForSamePubKey(t *testing.T) {
 		"",
 		nil,
 		false,
+		nil,
 	)
 	bidsMap.Store(testBuilderPubkey1, highBid)
 
@@ -465,6 +470,7 @@ func TestBlockCancellationForSamePubKey(t *testing.T) {
 		"",
 		nil,
 		false,
+		nil,
 	)
 	bidsMap.Store(testBuilderPubkey1, mediumBid)
 
@@ -484,6 +490,7 @@ func TestBlockCancellationForSamePubKey(t *testing.T) {
 		"",
 		nil,
 		false,
+		nil,
 	)
 	bidsMap.Store(testBuilderPubkey2, lowBid1)
 
@@ -502,6 +509,7 @@ func TestBlockCancellationForSamePubKey(t *testing.T) {
 		"",
 		nil,
 		false,
+		nil,
 	)
 	bidsMap.Store(testBuilderPubkey2, mediumBid1)
 
@@ -520,6 +528,7 @@ func TestBlockCancellationForSamePubKey(t *testing.T) {
 		"",
 		nil,
 		false,
+		nil,
 	)
 	bidsMap.Store(testBuilderPubkey2, highBid1)
 
@@ -539,6 +548,7 @@ func TestBlockCancellationForSamePubKey(t *testing.T) {
 		"",
 		nil,
 		false,
+		nil,
 	)
 	bidsMap.Store(testBuilderPubkey3, mediumBid2)
 
@@ -557,6 +567,7 @@ func TestBlockCancellationForSamePubKey(t *testing.T) {
 		"",
 		nil,
 		false,
+		nil,
 	)
 	bidsMap.Store(testBuilderPubkey3, highBid2)
 
@@ -575,6 +586,7 @@ func TestBlockCancellationForSamePubKey(t *testing.T) {
 		"",
 		nil,
 		false,
+		nil,
 	)
 	bidsMap.Store(testBuilderPubkey3, lowBid2)
 


### PR DESCRIPTION
## 📝 Summary

Send bid adjustment data inside `StreamHeaderResponse` struct so all nodes will have it immediately available.

## 💡 Motivation and Context

<!--- (Optional) Why is this change required? What problem does it solve? Remove this section if not applicable. -->

---

## ✅ I have completed the following steps:

* [ ] Run `make lint`
* [ ] Run `make test`
* [ ] Run `go mod tidy`
* [ ] Added tests (if applicable)
