### PR TITLE
MEV-1937/RelayProxy-add-region-for-ParentClient-struct

### DIFF
--- a/common/types.go
+++ b/common/types.go
@@ -377,6 +377,7 @@ type Client struct {
 type ParentClient struct {
 	FastClient *Client
 	SafeClient *Client
+	Region     string
 }
 
 func (p *ParentClient) String() string {
@@ -390,7 +391,13 @@ func (p *ParentClient) GetActiveClient(lastConnectTime time.Time) (*Client, bool
 	return p.FastClient, false
 }
 
-func NewParentClient(safeUrl string, safeConn *grpc.ClientConn, fastUrl string, fastConn *grpc.ClientConn) *ParentClient {
+func NewParentClient(
+	safeUrl string,
+	safeConn *grpc.ClientConn,
+	fastUrl string,
+	fastConn *grpc.ClientConn,
+	region string,
+) *ParentClient {
 	return &ParentClient{
 		FastClient: &Client{
 			URL:         fastUrl,
@@ -400,6 +407,7 @@ func NewParentClient(safeUrl string, safeConn *grpc.ClientConn, fastUrl string, 
 			URL:         safeUrl,
 			RelayClient: relaygrpc.NewRelayClient(safeConn),
 		},
+		Region: region,
 	}
 }
 

--- a/service_test.go
+++ b/service_test.go
@@ -634,11 +634,11 @@ func TestService_StreamHeaderAndGetMethod(t *testing.T) {
 	defer conn.Close()
 	dSvc := NewDataService(WithDataSvcLogger(zerolog.Nop()))
 	svcOpts := make([]ServiceOption, 0)
-	c := common.NewParentClient(lis.Addr().String(), conn, lis.Addr().String(), conn)
+	c := common.NewParentClient(lis.Addr().String(), conn, lis.Addr().String(), conn, "")
 	clients := []*common.ParentClient{c}
-	sc := common.NewParentClient(lis.Addr().String(), conn, lis.Addr().String(), conn)
+	sc := common.NewParentClient(lis.Addr().String(), conn, lis.Addr().String(), conn, "")
 	streamingClients := []*common.ParentClient{sc}
-	registrationClient := common.NewParentClient(lis.Addr().String(), conn, lis.Addr().String(), conn)
+	registrationClient := common.NewParentClient(lis.Addr().String(), conn, lis.Addr().String(), conn, "")
 	registrationClients := []*common.ParentClient{registrationClient}
 	tracer := noop.NewTracerProvider().Tracer("test")
 	svcOpts = append(svcOpts, WithSvcLogger(l))


### PR DESCRIPTION
## 📝 Summary

Adds `Region` field to `ParentClient` struct (to be used for proxy communication)

## 💡 Motivation and Context

<!--- (Optional) Why is this change required? What problem does it solve? Remove this section if not applicable. -->

---

## ✅ I have completed the following steps:

* [ ] Run `make lint`
* [ ] Run `make test`
* [ ] Run `go mod tidy`
* [ ] Added tests (if applicable)
