### PR TITLE
MEV-1977: Raise HTTP server IdleTimeout 10s -> 90s

### DIFF
--- a/server.go
+++ b/server.go
@@ -131,7 +131,7 @@ func (s *Server) Start(fallbackHandler http.Handler) error {
 		ReadTimeout:       0,
 		ReadHeaderTimeout: 0,
 		WriteTimeout:      0,
-		IdleTimeout:       10 * time.Second,
+		IdleTimeout:       90 * time.Second,
 	}
 
 	err := s.server.ListenAndServe()


### PR DESCRIPTION
Raise the validator-facing HTTP server IdleTimeout so the app is no longer the shortest link in the CloudFront/ALB/app keep-alive chain (app 90s > ALB 60s > CloudFront 10s), preventing intermittent 502 AbortedOrigin on pooled-connection reuse.

## 📝 Summary

<!--- A general summary of your changes -->

## 💡 Motivation and Context

<!--- (Optional) Why is this change required? What problem does it solve? Remove this section if not applicable. -->

---

## ✅ I have completed the following steps:

* [ ] Run `make lint`
* [ ] Run `make test`
* [ ] Run `go mod tidy`
* [ ] Added tests (if applicable)
