### PR TITLE
MEV-1984/RelayProxy-investigate-and-address-new-Proxy-memory-issues

### DIFF
--- a/cmd/relayproxy/main.go
+++ b/cmd/relayproxy/main.go
@@ -84,6 +84,8 @@ var (
 	network          = flag.String("network", defaultNetwork, "which network to use")
 	skipAuth         = flag.Bool("skip-auth", false, "auth header authentication skip flag")
 
+	disableFlowRecording = flag.Bool("disable-flow-recording", false, "disable in-memory request flow recording (/flows debug data)")
+
 	// external relay
 	externalRelayURL = flag.String("external-relay", "", "external relay to be called")
 	mainMEVRelays    = flag.String("main-mev-relays", "", "CSV of redirect urls for Main MEV Relays")
@@ -375,6 +377,7 @@ func main() {
 	dataSvcOpts = append(dataSvcOpts, relayproxy.WithGetHeaderDelaySettings(delaySettings))
 	dataSvcOpts = append(dataSvcOpts, relayproxy.WithGetHeaderTimeout(timeout))
 	dataSvcOpts = append(dataSvcOpts, relayproxy.WithAccountImportLists(accountsLists))
+	dataSvcOpts = append(dataSvcOpts, relayproxy.WithFlowRecordingDisabled(*disableFlowRecording))
 
 	dataSvc := relayproxy.NewDataService(dataSvcOpts...)
 

--- a/dataservice.go
+++ b/dataservice.go
@@ -21,8 +21,8 @@ const (
 	GetHeaderRequestCutoffMs             = 3000
 	delayEligibilityCacheCleanupInterval = 60 * time.Second
 
-	flowRetention       = 3 * 24 * time.Hour // keep in-memory for 3 days
-	flowCleanupInterval = 5 * time.Minute    // how often expired entries are purged
+	flowRetention       = time.Hour       // keep in-memory long enough for on-call /flows debugging; records grow ~25MB/h so longer retention eats OOM headroom (MEV-1984)
+	flowCleanupInterval = 5 * time.Minute // how often expired entries are purged
 )
 
 type IDataService interface {

--- a/dataservice.go
+++ b/dataservice.go
@@ -21,7 +21,7 @@ const (
 	GetHeaderRequestCutoffMs             = 3000
 	delayEligibilityCacheCleanupInterval = 60 * time.Second
 
-	flowRetention       = time.Hour       // keep in-memory long enough for on-call /flows debugging; records grow ~25MB/h so longer retention eats OOM headroom (MEV-1984)
+	flowRetention       = time.Hour       // keep in-memory long enough for on-call /flows debugging
 	flowCleanupInterval = 5 * time.Minute // how often expired entries are purged
 )
 

--- a/flowservice.go
+++ b/flowservice.go
@@ -273,7 +273,7 @@ func (fs *FlowService) RecordGetPayload(slot uint64, parentHash, blockHash, prop
 
 func (fs *FlowService) GetAllFlowsSnapshot() map[string]*FlowRecord {
 	if fs.flowCache == nil {
-		return nil
+		return map[string]*FlowRecord{}
 	}
 	fs.mu.RLock()
 	defer fs.mu.RUnlock()
@@ -290,7 +290,7 @@ func (fs *FlowService) GetAllFlowsSnapshot() map[string]*FlowRecord {
 
 func (fs *FlowService) GetFlowsBySlot(slot uint64) []*FlowRecord {
 	if fs.flowCache == nil {
-		return nil
+		return []*FlowRecord{}
 	}
 	fs.mu.RLock()
 	defer fs.mu.RUnlock()
@@ -311,7 +311,7 @@ func (fs *FlowService) GetFlowsBySlot(slot uint64) []*FlowRecord {
 
 func (fs *FlowService) GetFlowsBySlotAndBlock(slot uint64, blockHash string) []*FlowRecord {
 	if fs.flowCache == nil {
-		return nil
+		return []*FlowRecord{}
 	}
 	fs.mu.RLock()
 	defer fs.mu.RUnlock()

--- a/opts.go
+++ b/opts.go
@@ -379,6 +379,16 @@ func WithDataSvcNodeID(nodeID string) DataServiceOption {
 	}
 }
 
+// WithFlowRecordingDisabled turns off in-memory request flow recording (the /flows debug
+// data). A FlowService with a nil cache makes every Record*/Get* method a no-op.
+func WithFlowRecordingDisabled(disabled bool) DataServiceOption {
+	return func(s *DataService) {
+		if disabled {
+			s.flowSvc = &FlowService{}
+		}
+	}
+}
+
 func WithDataSvcTracer(tracer trace.Tracer) DataServiceOption {
 	return func(s *DataService) {
 		s.tracer = tracer


### PR DESCRIPTION
Takes flow service retention down from 3 days to 1 hour, and adds a `disable-flow-recording` boolean flag

---

## ✅ I have completed the following steps:

* [ ] Run `make lint`
* [ ] Run `make test`
* [ ] Run `go mod tidy`
* [ ] Added tests (if applicable)
