### PR TITLE
MEV-1985/RelayProxy-add-registration-queue-and worker-pool

### DIFF
--- a/cmd/relayproxy/main.go
+++ b/cmd/relayproxy/main.go
@@ -84,6 +84,8 @@ var (
 	network          = flag.String("network", defaultNetwork, "which network to use")
 	skipAuth         = flag.Bool("skip-auth", false, "auth header authentication skip flag")
 
+	disableFlowRecording = flag.Bool("disable-flow-recording", false, "disable in-memory request flow recording (/flows debug data)")
+
 	// external relay
 	externalRelayURL = flag.String("external-relay", "", "external relay to be called")
 	mainMEVRelays    = flag.String("main-mev-relays", "", "CSV of redirect urls for Main MEV Relays")
@@ -375,6 +377,7 @@ func main() {
 	dataSvcOpts = append(dataSvcOpts, relayproxy.WithGetHeaderDelaySettings(delaySettings))
 	dataSvcOpts = append(dataSvcOpts, relayproxy.WithGetHeaderTimeout(timeout))
 	dataSvcOpts = append(dataSvcOpts, relayproxy.WithAccountImportLists(accountsLists))
+	dataSvcOpts = append(dataSvcOpts, relayproxy.WithFlowRecordingDisabled(*disableFlowRecording))
 
 	dataSvc := relayproxy.NewDataService(dataSvcOpts...)
 

--- a/dataservice.go
+++ b/dataservice.go
@@ -21,8 +21,8 @@ const (
 	GetHeaderRequestCutoffMs             = 3000
 	delayEligibilityCacheCleanupInterval = 60 * time.Second
 
-	flowRetention       = 3 * 24 * time.Hour // keep in-memory for 3 days
-	flowCleanupInterval = 5 * time.Minute    // how often expired entries are purged
+	flowRetention       = time.Hour       // keep in-memory long enough for on-call /flows debugging; records grow ~25MB/h so longer retention eats OOM headroom (MEV-1984)
+	flowCleanupInterval = 5 * time.Minute // how often expired entries are purged
 )
 
 type IDataService interface {

--- a/dataservice.go
+++ b/dataservice.go
@@ -21,7 +21,7 @@ const (
 	GetHeaderRequestCutoffMs             = 3000
 	delayEligibilityCacheCleanupInterval = 60 * time.Second
 
-	flowRetention       = time.Hour       // keep in-memory long enough for on-call /flows debugging; records grow ~25MB/h so longer retention eats OOM headroom (MEV-1984)
+	flowRetention       = time.Hour       // keep in-memory long enough for on-call /flows debugging
 	flowCleanupInterval = 5 * time.Minute // how often expired entries are purged
 )
 

--- a/flowservice.go
+++ b/flowservice.go
@@ -273,7 +273,7 @@ func (fs *FlowService) RecordGetPayload(slot uint64, parentHash, blockHash, prop
 
 func (fs *FlowService) GetAllFlowsSnapshot() map[string]*FlowRecord {
 	if fs.flowCache == nil {
-		return nil
+		return map[string]*FlowRecord{}
 	}
 	fs.mu.RLock()
 	defer fs.mu.RUnlock()
@@ -290,7 +290,7 @@ func (fs *FlowService) GetAllFlowsSnapshot() map[string]*FlowRecord {
 
 func (fs *FlowService) GetFlowsBySlot(slot uint64) []*FlowRecord {
 	if fs.flowCache == nil {
-		return nil
+		return []*FlowRecord{}
 	}
 	fs.mu.RLock()
 	defer fs.mu.RUnlock()
@@ -311,7 +311,7 @@ func (fs *FlowService) GetFlowsBySlot(slot uint64) []*FlowRecord {
 
 func (fs *FlowService) GetFlowsBySlotAndBlock(slot uint64, blockHash string) []*FlowRecord {
 	if fs.flowCache == nil {
-		return nil
+		return []*FlowRecord{}
 	}
 	fs.mu.RLock()
 	defer fs.mu.RUnlock()

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	go.opentelemetry.io/otel v1.36.0
 	go.opentelemetry.io/otel/trace v1.36.0
 	go.uber.org/zap v1.27.0
+	golang.org/x/sync v0.14.0
 	google.golang.org/grpc v1.74.2
 	google.golang.org/protobuf v1.36.6
 	gopkg.in/yaml.v2 v2.4.0
@@ -84,7 +85,6 @@ require (
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/crypto v0.38.0 // indirect
 	golang.org/x/net v0.40.0 // indirect
-	golang.org/x/sync v0.14.0 // indirect
 	golang.org/x/sys v0.33.0 // indirect
 	golang.org/x/text v0.25.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20250528174236-200df99c418a // indirect

--- a/opts.go
+++ b/opts.go
@@ -379,6 +379,16 @@ func WithDataSvcNodeID(nodeID string) DataServiceOption {
 	}
 }
 
+// WithFlowRecordingDisabled turns off in-memory request flow recording (the /flows debug
+// data). A FlowService with a nil cache makes every Record*/Get* method a no-op.
+func WithFlowRecordingDisabled(disabled bool) DataServiceOption {
+	return func(s *DataService) {
+		if disabled {
+			s.flowSvc = &FlowService{}
+		}
+	}
+}
+
 func WithDataSvcTracer(tracer trace.Tracer) DataServiceOption {
 	return func(s *DataService) {
 		s.tracer = tracer

--- a/registration.go
+++ b/registration.go
@@ -198,11 +198,13 @@ func (s *Service) monitorRegistrationQueue() {
 		forwardedOK := s.regForwardedOK.Swap(0)
 		failedAttempts := s.regForwardFailedAttempts.Swap(0)
 		dropped := s.regForwardDropped.Swap(0)
+		succeededAfterRetry := s.regSucceededAfterRetry.Swap(0)
 		if forwardedOK != 0 || failedAttempts != 0 || dropped != 0 {
 			s.logger.Info().
 				Int64("forwardedOK", forwardedOK).
 				Int64("failedAttempts", failedAttempts).
 				Int64("dropped", dropped).
+				Int64("succeededAfterRetry", succeededAfterRetry).
 				Dur("interval", regQueueMonitorInterval).
 				Msg("Registration forwarding stats")
 		}
@@ -260,6 +262,9 @@ func (s *Service) forwardRegistration(task *registrationTask) {
 
 		if errResp == nil {
 			s.regForwardedOK.Add(1)
+			if task.attempts > 1 {
+				s.regSucceededAfterRetry.Add(1)
+			}
 			return
 		}
 		s.regForwardFailedAttempts.Add(1)

--- a/registration.go
+++ b/registration.go
@@ -42,10 +42,13 @@ const (
 	// registration volume observed through one proxy is only tens of MB.
 	regQueueMaxBytes = 768 << 20
 	// regMaxInFlightBytes caps the total payload bytes being forwarded
-	// concurrently (at the observed ~200KB per batch this allows ~1300 parallel
-	// forwards); regMaxInFlightTasks additionally bounds goroutine count when
-	// payloads are tiny.
-	regMaxInFlightBytes     = 256 << 20
+	// concurrently — at the observed ~200KB per batch this allows ~330 parallel
+	// forwards, draining an epoch-boundary burst in seconds. Note gRPC amplifies
+	// each in-flight payload ~7-9x in heap (marshal copy, transport and pooled
+	// response buffers, measured 2026-07-16), so the real transient cost is
+	// several times this budget; regMaxInFlightTasks additionally bounds
+	// goroutine count when payloads are tiny.
+	regMaxInFlightBytes     = 64 << 20
 	regMaxInFlightTasks     = 4096
 	regForwardMaxAttempts   = 3
 	regForwardRetryBackoff  = time.Second
@@ -173,24 +176,36 @@ func (s *Service) ensureRegistrationWorkers() {
 	})
 }
 
-// monitorRegistrationQueue periodically logs the registration queue backlog so
-// its distance from the regQueueMaxTasks/regQueueMaxBytes limits can be
-// monitored; quiet while the queue is empty.
+// monitorRegistrationQueue periodically logs the registration queue backlog
+// (quiet while the queue is empty) and the forwarding outcomes since the last
+// tick — forwardedOK is the positive confirmation that registrations are
+// reaching the relays (quiet when there was no registration activity at all).
 func (s *Service) monitorRegistrationQueue() {
 	ticker := time.NewTicker(regQueueMonitorInterval)
 	defer ticker.Stop()
 	for range ticker.C {
 		queuedTasks := len(s.registrationQueue)
 		queuedBytes := s.registrationQueueBytes.Load()
-		if queuedTasks == 0 && queuedBytes == 0 {
-			continue
+		if queuedTasks != 0 || queuedBytes != 0 {
+			s.logger.Info().
+				Int("queuedTasks", queuedTasks).
+				Int("maxTasks", regQueueMaxTasks).
+				Int64("queuedBytes", queuedBytes).
+				Int64("maxBytes", regQueueMaxBytes).
+				Msg("Registration queue backlog")
 		}
-		s.logger.Info().
-			Int("queuedTasks", queuedTasks).
-			Int("maxTasks", regQueueMaxTasks).
-			Int64("queuedBytes", queuedBytes).
-			Int64("maxBytes", regQueueMaxBytes).
-			Msg("Registration queue backlog")
+
+		forwardedOK := s.regForwardedOK.Swap(0)
+		failedAttempts := s.regForwardFailedAttempts.Swap(0)
+		dropped := s.regForwardDropped.Swap(0)
+		if forwardedOK != 0 || failedAttempts != 0 || dropped != 0 {
+			s.logger.Info().
+				Int64("forwardedOK", forwardedOK).
+				Int64("failedAttempts", failedAttempts).
+				Int64("dropped", dropped).
+				Dur("interval", regQueueMonitorInterval).
+				Msg("Registration forwarding stats")
+		}
 	}
 }
 
@@ -244,10 +259,13 @@ func (s *Service) forwardRegistration(task *registrationTask) {
 		cancel()
 
 		if errResp == nil {
+			s.regForwardedOK.Add(1)
 			return
 		}
+		s.regForwardFailedAttempts.Add(1)
 
 		if task.attempts >= regForwardMaxAttempts || !isRetryableRegistrationError(errResp) {
+			s.regForwardDropped.Add(1)
 			task.log.Error().Str("err", errResp.Error()).Int("attempts", task.attempts).Msg("Dropping validator registration")
 			return
 		}

--- a/registration.go
+++ b/registration.go
@@ -13,19 +13,24 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	otelcodes "go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
+	"golang.org/x/sync/semaphore"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-// Registration forwarding is asynchronous: RegisterValidator enqueues and a fixed
-// worker pool forwards to the registration relays, each attempt with its own
-// deadline. The queue is bounded by task count and total payload bytes, so a
-// registration burst against slow relays pins a bounded amount of memory instead
-// of accumulating unbounded gRPC send buffers (MEV-1984). When full, the oldest
-// queued registrations are shed (drop-oldest) so clients always receive success —
-// validators re-send every epoch, and a saturated queue means the registration
-// relays are failing, where delivery would fail under any shedding policy.
+// Registration forwarding is asynchronous: RegisterValidator enqueues, and a
+// dispatcher forwards each registration in its own goroutine with its own
+// deadline, gated by an in-flight byte budget rather than a fixed worker count.
+// Epoch boundaries deliver thousands of ~200KB batches within seconds, so drain
+// concurrency must scale with the burst (a fixed 16-worker pool caused ~250
+// drop-oldest evictions per epoch); the relays have always absorbed this
+// concurrency — the byte budget only caps how much memory in-flight requests can
+// pin when relays stall (MEV-1984/MEV-1985). The queue is bounded by task count
+// and total payload bytes; when it overflows, the oldest queued registrations
+// are shed (drop-oldest) so clients always receive success — validators re-send
+// every epoch, and a saturated queue means the registration relays are failing,
+// where delivery would fail under any shedding policy.
 const (
 	// maxRegistrationPayloadBytes is anti-abuse only and must stay far above any
 	// legitimate batch: every mainnet validator (~880k) registering in a single
@@ -35,8 +40,13 @@ const (
 	// regQueueMaxBytes must be >= maxRegistrationPayloadBytes so a max-size
 	// request can always enqueue into an empty queue; typical epoch-wide
 	// registration volume observed through one proxy is only tens of MB.
-	regQueueMaxBytes        = 768 << 20
-	regQueueWorkers         = 16
+	regQueueMaxBytes = 768 << 20
+	// regMaxInFlightBytes caps the total payload bytes being forwarded
+	// concurrently (at the observed ~200KB per batch this allows ~1300 parallel
+	// forwards); regMaxInFlightTasks additionally bounds goroutine count when
+	// payloads are tiny.
+	regMaxInFlightBytes     = 256 << 20
+	regMaxInFlightTasks     = 4096
 	regForwardMaxAttempts   = 3
 	regForwardRetryBackoff  = time.Second
 	regQueueMonitorInterval = 30 * time.Second
@@ -156,9 +166,9 @@ func (s *Service) ensureRegistrationWorkers() {
 		if s.registrationQueue == nil {
 			s.registrationQueue = make(chan *registrationTask, regQueueMaxTasks)
 		}
-		for range regQueueWorkers {
-			go s.registrationWorker()
-		}
+		s.regInFlightBytes = semaphore.NewWeighted(regMaxInFlightBytes)
+		s.regInFlightSlots = make(chan struct{}, regMaxInFlightTasks)
+		go s.registrationDispatcher()
 		go s.monitorRegistrationQueue()
 	})
 }
@@ -184,10 +194,29 @@ func (s *Service) monitorRegistrationQueue() {
 	}
 }
 
-func (s *Service) registrationWorker() {
+// registrationDispatcher drains the queue, forwarding each registration in its
+// own goroutine. Concurrency is limited by the in-flight byte budget and task
+// slot cap; when both are exhausted (relays stalled with the budget's worth of
+// requests outstanding) the dispatcher blocks, applying backpressure into the
+// bounded queue, whose drop-oldest overflow is then the shedding mechanism.
+func (s *Service) registrationDispatcher() {
 	for task := range s.registrationQueue {
-		s.registrationQueueBytes.Add(-int64(len(task.req.Payload)))
-		s.forwardRegistration(task)
+		payloadBytes := int64(len(task.req.Payload))
+		// clamp: a payload above the whole budget (allowed up to
+		// maxRegistrationPayloadBytes) must not block Acquire forever
+		weight := min(payloadBytes, regMaxInFlightBytes)
+		s.regInFlightSlots <- struct{}{}
+		// weighted Acquire only fails on ctx cancellation; Background never cancels
+		_ = s.regInFlightBytes.Acquire(context.Background(), weight)
+		s.registrationQueueBytes.Add(-payloadBytes)
+
+		go func(t *registrationTask, n int64) {
+			defer func() {
+				s.regInFlightBytes.Release(n)
+				<-s.regInFlightSlots
+			}()
+			s.forwardRegistration(t)
+		}(task, weight)
 	}
 }
 

--- a/registration.go
+++ b/registration.go
@@ -205,7 +205,7 @@ func (s *Service) monitorRegistrationQueue() {
 				Int64("failedAttempts", failedAttempts).
 				Int64("dropped", dropped).
 				Int64("succeededAfterRetry", succeededAfterRetry).
-				Dur("interval", regQueueMonitorInterval).
+				Str("interval", regQueueMonitorInterval.String()).
 				Msg("Registration forwarding stats")
 		}
 	}

--- a/registration.go
+++ b/registration.go
@@ -22,7 +22,10 @@ import (
 // worker pool forwards to the registration relays, each attempt with its own
 // deadline. The queue is bounded by task count and total payload bytes, so a
 // registration burst against slow relays pins a bounded amount of memory instead
-// of accumulating unbounded gRPC send buffers (MEV-1984).
+// of accumulating unbounded gRPC send buffers (MEV-1984). When full, the oldest
+// queued registrations are shed (drop-oldest) so clients always receive success —
+// validators re-send every epoch, and a saturated queue means the registration
+// relays are failing, where delivery would fail under any shedding policy.
 const (
 	// maxRegistrationPayloadBytes is anti-abuse only and must stay far above any
 	// legitimate batch: every mainnet validator (~880k) registering in a single
@@ -93,31 +96,58 @@ func (s *Service) RegisterValidator(ctx context.Context, log *zerolog.Logger, ou
 	task := &registrationTask{req: req, md: md, log: *log}
 
 	s.ensureRegistrationWorkers()
+	s.enqueueRegistration(task, span)
+	return struct{}{}, nil
+}
 
-	payloadBytes := int64(len(in.Payload))
-	if s.registrationQueueBytes.Add(payloadBytes) > regQueueMaxBytes {
-		s.registrationQueueBytes.Add(-payloadBytes)
-		span.SetStatus(otelcodes.Error, "registration queue byte limit reached")
-		log.Error().
-			Int64("payloadBytes", payloadBytes).
-			Int("queuedTasks", len(s.registrationQueue)).
-			Int64("queuedBytes", s.registrationQueueBytes.Load()).
-			Msg("Registration queue byte limit reached, rejecting registration with 503")
-		return nil, toErrorResp(http.StatusServiceUnavailable, "registration queue is full")
+// enqueueRegistration adds a registration to the forwarding queue, evicting the
+// oldest queued registrations to make room when the task or byte cap is hit
+// (drop-oldest). Clients therefore always get a success response; shed
+// registrations are logged and re-sent by validators on their next epoch cycle.
+// A saturated queue only occurs when the registration relays are failing, in
+// which case delivery would fail regardless of shedding policy.
+func (s *Service) enqueueRegistration(task *registrationTask, span trace.Span) {
+	payloadBytes := int64(len(task.req.Payload))
+	s.registrationQueueBytes.Add(payloadBytes)
+
+	// bounded so a pathological race with concurrent enqueuers cannot spin forever
+	for range regQueueMaxTasks + 1 {
+		if s.registrationQueueBytes.Load() <= regQueueMaxBytes {
+			select {
+			case s.registrationQueue <- task:
+				return
+			default:
+			}
+		}
+		if !s.evictOldestRegistration(span) {
+			break // nothing left to evict yet still no room: give up on the new task
+		}
 	}
 
+	s.registrationQueueBytes.Add(-payloadBytes)
+	span.SetStatus(otelcodes.Error, "registration dropped, could not make room in queue")
+	task.log.Error().
+		Int64("payloadBytes", payloadBytes).
+		Int("queuedTasks", len(s.registrationQueue)).
+		Int64("queuedBytes", s.registrationQueueBytes.Load()).
+		Msg("Dropping registration, could not make room in full queue")
+}
+
+// evictOldestRegistration sheds the head of the queue (the oldest pending
+// registration). Reports false when the queue is empty.
+func (s *Service) evictOldestRegistration(span trace.Span) bool {
 	select {
-	case s.registrationQueue <- task:
-		return struct{}{}, nil
-	default:
-		s.registrationQueueBytes.Add(-payloadBytes)
-		span.SetStatus(otelcodes.Error, "registration queue task limit reached")
-		log.Error().
-			Int64("payloadBytes", payloadBytes).
+	case dropped := <-s.registrationQueue:
+		s.registrationQueueBytes.Add(-int64(len(dropped.req.Payload)))
+		span.AddEvent("evicted oldest queued registration")
+		dropped.log.Error().
+			Int("payloadBytes", len(dropped.req.Payload)).
 			Int("queuedTasks", len(s.registrationQueue)).
 			Int64("queuedBytes", s.registrationQueueBytes.Load()).
-			Msg("Registration queue task limit reached, rejecting registration with 503")
-		return nil, toErrorResp(http.StatusServiceUnavailable, "registration queue is full")
+			Msg("Evicting oldest queued registration to admit a newer one")
+		return true
+	default:
+		return false
 	}
 }
 

--- a/registration.go
+++ b/registration.go
@@ -32,10 +32,11 @@ const (
 	// regQueueMaxBytes must be >= maxRegistrationPayloadBytes so a max-size
 	// request can always enqueue into an empty queue; typical epoch-wide
 	// registration volume observed through one proxy is only tens of MB.
-	regQueueMaxBytes       = 768 << 20
-	regQueueWorkers        = 16
-	regForwardMaxAttempts  = 3
-	regForwardRetryBackoff = time.Second
+	regQueueMaxBytes        = 768 << 20
+	regQueueWorkers         = 16
+	regForwardMaxAttempts   = 3
+	regForwardRetryBackoff  = time.Second
+	regQueueMonitorInterval = 30 * time.Second
 )
 
 // registrationTask is one registration waiting to be forwarded to the relays.
@@ -97,7 +98,11 @@ func (s *Service) RegisterValidator(ctx context.Context, log *zerolog.Logger, ou
 	if s.registrationQueueBytes.Add(payloadBytes) > regQueueMaxBytes {
 		s.registrationQueueBytes.Add(-payloadBytes)
 		span.SetStatus(otelcodes.Error, "registration queue byte limit reached")
-		log.Error().Int64("payloadBytes", payloadBytes).Msg("registration queue byte limit reached, rejecting registration")
+		log.Error().
+			Int64("payloadBytes", payloadBytes).
+			Int("queuedTasks", len(s.registrationQueue)).
+			Int64("queuedBytes", s.registrationQueueBytes.Load()).
+			Msg("Registration queue byte limit reached, rejecting registration with 503")
 		return nil, toErrorResp(http.StatusServiceUnavailable, "registration queue is full")
 	}
 
@@ -107,7 +112,11 @@ func (s *Service) RegisterValidator(ctx context.Context, log *zerolog.Logger, ou
 	default:
 		s.registrationQueueBytes.Add(-payloadBytes)
 		span.SetStatus(otelcodes.Error, "registration queue task limit reached")
-		log.Error().Msg("registration queue task limit reached, rejecting registration")
+		log.Error().
+			Int64("payloadBytes", payloadBytes).
+			Int("queuedTasks", len(s.registrationQueue)).
+			Int64("queuedBytes", s.registrationQueueBytes.Load()).
+			Msg("Registration queue task limit reached, rejecting registration with 503")
 		return nil, toErrorResp(http.StatusServiceUnavailable, "registration queue is full")
 	}
 }
@@ -120,7 +129,29 @@ func (s *Service) ensureRegistrationWorkers() {
 		for range regQueueWorkers {
 			go s.registrationWorker()
 		}
+		go s.monitorRegistrationQueue()
 	})
+}
+
+// monitorRegistrationQueue periodically logs the registration queue backlog so
+// its distance from the regQueueMaxTasks/regQueueMaxBytes limits can be
+// monitored; quiet while the queue is empty.
+func (s *Service) monitorRegistrationQueue() {
+	ticker := time.NewTicker(regQueueMonitorInterval)
+	defer ticker.Stop()
+	for range ticker.C {
+		queuedTasks := len(s.registrationQueue)
+		queuedBytes := s.registrationQueueBytes.Load()
+		if queuedTasks == 0 && queuedBytes == 0 {
+			continue
+		}
+		s.logger.Info().
+			Int("queuedTasks", queuedTasks).
+			Int("maxTasks", regQueueMaxTasks).
+			Int64("queuedBytes", queuedBytes).
+			Int64("maxBytes", regQueueMaxBytes).
+			Msg("Registration queue backlog")
+	}
 }
 
 func (s *Service) registrationWorker() {

--- a/registration.go
+++ b/registration.go
@@ -18,19 +18,37 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-func (s *Service) RegisterValidator(ctx context.Context, log *zerolog.Logger, outgoingCtx context.Context, in *RegistrationParams) (any, error) {
-	var (
-		errChan  = make(chan *ErrorResp, len(s.clients))
-		respChan = make(chan *relaygrpc.RegisterValidatorResponse, len(s.clients))
-		_err     *ErrorResp
-	)
-	timer := time.NewTimer(regRequestTimeout)
-	defer timer.Stop()
+// Registration forwarding is asynchronous: RegisterValidator enqueues and a fixed
+// worker pool forwards to the registration relays, each attempt with its own
+// deadline. The queue is bounded by task count and total payload bytes, so a
+// registration burst against slow relays pins a bounded amount of memory instead
+// of accumulating unbounded gRPC send buffers (MEV-1984).
+const (
+	// maxRegistrationPayloadBytes is anti-abuse only and must stay far above any
+	// legitimate batch: every mainnet validator (~880k) registering in a single
+	// request is ~160MB SSZ / ~440MB JSON at ~180/~500 bytes per registration.
+	maxRegistrationPayloadBytes = 512 << 20
+	regQueueMaxTasks            = 4096 // max queued registrations
+	// regQueueMaxBytes must be >= maxRegistrationPayloadBytes so a max-size
+	// request can always enqueue into an empty queue; typical epoch-wide
+	// registration volume observed through one proxy is only tens of MB.
+	regQueueMaxBytes       = 768 << 20
+	regQueueWorkers        = 16
+	regForwardMaxAttempts  = 3
+	regForwardRetryBackoff = time.Second
+)
 
+// registrationTask is one registration waiting to be forwarded to the relays.
+type registrationTask struct {
+	req      *relaygrpc.RegisterValidatorRequest
+	md       metadata.MD // outgoing metadata captured from the handler (e.g. ssz content type)
+	log      zerolog.Logger
+	attempts int
+}
+
+func (s *Service) RegisterValidator(ctx context.Context, log *zerolog.Logger, outgoingCtx context.Context, in *RegistrationParams) (any, error) {
 	parentSpan := trace.SpanFromContext(ctx)
-	ctx = trace.ContextWithSpan(outgoingCtx, parentSpan)
-	ctx = metadata.AppendToOutgoingContext(ctx, "authorization", s.authKey)
-	ctx, span := s.tracer.Start(ctx, "registerValidator-start")
+	_, span := s.tracer.Start(ctx, "registerValidator-enqueue")
 	defer span.End()
 
 	id := uuid.NewString()
@@ -70,41 +88,90 @@ func (s *Service) RegisterValidator(ctx context.Context, log *zerolog.Logger, ou
 		SkipOptimism:       in.SkipOptimism,
 	}
 
-	ctx, spanWait := s.tracer.Start(ctx, "RegisterValidator-waitForResponse")
-	go func(_ctx context.Context, req *relaygrpc.RegisterValidatorRequest) {
-		defer spanWait.End()
+	md, _ := metadata.FromOutgoingContext(outgoingCtx)
+	task := &registrationTask{req: req, md: md, log: *log}
 
-		out, err := s.registerValidatorForClient(ctx, req)
-		if err != nil {
-			spanWait.SetAttributes(attribute.String("error", err.Error()))
-			errChan <- err
+	s.ensureRegistrationWorkers()
+
+	payloadBytes := int64(len(in.Payload))
+	if s.registrationQueueBytes.Add(payloadBytes) > regQueueMaxBytes {
+		s.registrationQueueBytes.Add(-payloadBytes)
+		span.SetStatus(otelcodes.Error, "registration queue byte limit reached")
+		log.Error().Int64("payloadBytes", payloadBytes).Msg("registration queue byte limit reached, rejecting registration")
+		return nil, toErrorResp(http.StatusServiceUnavailable, "registration queue is full")
+	}
+
+	select {
+	case s.registrationQueue <- task:
+		return struct{}{}, nil
+	default:
+		s.registrationQueueBytes.Add(-payloadBytes)
+		span.SetStatus(otelcodes.Error, "registration queue task limit reached")
+		log.Error().Msg("registration queue task limit reached, rejecting registration")
+		return nil, toErrorResp(http.StatusServiceUnavailable, "registration queue is full")
+	}
+}
+
+func (s *Service) ensureRegistrationWorkers() {
+	s.registrationWorkersOnce.Do(func() {
+		if s.registrationQueue == nil {
+			s.registrationQueue = make(chan *registrationTask, regQueueMaxTasks)
+		}
+		for range regQueueWorkers {
+			go s.registrationWorker()
+		}
+	})
+}
+
+func (s *Service) registrationWorker() {
+	for task := range s.registrationQueue {
+		s.registrationQueueBytes.Add(-int64(len(task.req.Payload)))
+		s.forwardRegistration(task)
+	}
+}
+
+// forwardRegistration sends one queued registration to the registration relays,
+// retrying transient failures with backoff. Each attempt carries its own deadline
+// so a stalled relay connection cannot pin the payload in transport buffers.
+func (s *Service) forwardRegistration(task *registrationTask) {
+	for {
+		task.attempts++
+
+		attemptCtx := context.Background()
+		if task.md != nil {
+			attemptCtx = metadata.NewOutgoingContext(attemptCtx, task.md)
+		}
+		attemptCtx = metadata.AppendToOutgoingContext(attemptCtx, "authorization", s.authKey)
+		attemptCtx, cancel := context.WithTimeout(attemptCtx, regRequestTimeout)
+		attemptCtx, span := s.tracer.Start(attemptCtx, "registerValidator-forward")
+		span.SetAttributes(
+			attribute.String("reqID", task.req.ReqId),
+			attribute.Int("attempt", task.attempts),
+		)
+
+		_, errResp := s.registerValidatorForClient(attemptCtx, task.req)
+		span.End()
+		cancel()
+
+		if errResp == nil {
 			return
 		}
-		respChan <- out
-	}(ctx, req)
 
-	ctx, spanSuccess := s.tracer.Start(ctx, "RegisterValidator-waitForSuccessfulResponse")
-	select {
-	case <-ctx.Done():
-		return nil, toErrorResp(http.StatusInternalServerError, ctx.Err().Error())
-	case _err = <-errChan:
-		// first error captured
-	case <-respChan:
-		return struct{}{}, nil
-	case <-timer.C:
-		log.Warn().Dur("timeout", regRequestTimeout).Msg("timer hit: relay request timeout")
-		return struct{}{}, nil
-	}
-	spanSuccess.End(trace.WithTimestamp(time.Now()))
-
-	if _err != nil {
-		if _err.Code == http.StatusRequestTimeout {
-			log.Info().Msg("relay request timeout")
-			return struct{}{}, nil
+		if task.attempts >= regForwardMaxAttempts || !isRetryableRegistrationError(errResp) {
+			task.log.Error().Str("err", errResp.Error()).Int("attempts", task.attempts).Msg("dropping validator registration")
+			return
 		}
-	}
 
-	return nil, _err
+		task.log.Warn().Str("err", errResp.Error()).Int("attempts", task.attempts).Msg("retrying validator registration")
+		time.Sleep(regForwardRetryBackoff)
+	}
+}
+
+// isRetryableRegistrationError reports whether a forward attempt is worth
+// retrying: relay rejections (4xx other than timeout) are permanent — e.g. an
+// expired or malformed registration — while timeouts and 5xx are transient.
+func isRetryableRegistrationError(errResp *ErrorResp) bool {
+	return errResp.Code == http.StatusRequestTimeout || errResp.Code >= http.StatusInternalServerError
 }
 
 func (s *Service) registerValidatorForClient(_ctx context.Context, req *relaygrpc.RegisterValidatorRequest) (*relaygrpc.RegisterValidatorResponse, *ErrorResp) {

--- a/registration.go
+++ b/registration.go
@@ -189,11 +189,11 @@ func (s *Service) forwardRegistration(task *registrationTask) {
 		}
 
 		if task.attempts >= regForwardMaxAttempts || !isRetryableRegistrationError(errResp) {
-			task.log.Error().Str("err", errResp.Error()).Int("attempts", task.attempts).Msg("dropping validator registration")
+			task.log.Error().Str("err", errResp.Error()).Int("attempts", task.attempts).Msg("Dropping validator registration")
 			return
 		}
 
-		task.log.Warn().Str("err", errResp.Error()).Int("attempts", task.attempts).Msg("retrying validator registration")
+		task.log.Warn().Str("err", errResp.Error()).Int("attempts", task.attempts).Msg("Retrying validator registration")
 		time.Sleep(regForwardRetryBackoff)
 	}
 }

--- a/server.go
+++ b/server.go
@@ -581,13 +581,13 @@ func (s *Server) HandleRegistration(w http.ResponseWriter, r *http.Request) {
 	bodyBytes, err := io.ReadAll(io.LimitReader(r.Body, maxRegistrationPayloadBytes+1))
 	if err != nil {
 		handleRegistrationSpan.SetStatus(codes.Error, err.Error())
-		log.Error().Err(err).Msg("could not read registration")
-		respondError(handleRegistrationCtx, handleRegistrationSpan, registration, w, toErrorResp(http.StatusInternalServerError, "could not read registration"), &log, s.tracer, receivedAt)
+		log.Error().Err(err).Msg("failed to read validator registration bytes")
+		respondError(handleRegistrationCtx, handleRegistrationSpan, registration, w, toErrorResp(http.StatusInternalServerError, "failed to read validator registration bytes"), &log, s.tracer, receivedAt)
 		return
 	}
 	if len(bodyBytes) > maxRegistrationPayloadBytes {
-		handleRegistrationSpan.SetStatus(codes.Error, "registration payload too large")
-		log.Error().Int("payloadBytes", len(bodyBytes)).Msg("registration payload too large")
+		handleRegistrationSpan.SetStatus(codes.Error, "Registration payload too large")
+		log.Error().Int("payloadBytes", len(bodyBytes)).Msg("Registration payload too large")
 		respondError(handleRegistrationCtx, handleRegistrationSpan, registration, w, toErrorResp(http.StatusRequestEntityTooLarge, "registration payload too large"), &log, s.tracer, receivedAt)
 		return
 	}
@@ -608,7 +608,7 @@ func (s *Server) HandleRegistration(w http.ResponseWriter, r *http.Request) {
 		handleRegistrationSpan.SetAttributes(
 			attribute.String("error", err.Error()),
 		)
-		log.Error().Err(err).Msg("error in RegisterValidator")
+		log.Error().Err(err).Msg("Error in RegisterValidator")
 		if errResp, ok := err.(*ErrorResp); ok && errResp.Code == http.StatusServiceUnavailable {
 			respondError(handleRegistrationCtx, handleRegistrationSpan, registration, w, errResp, &log, s.tracer, receivedAt)
 			return
@@ -885,8 +885,8 @@ func (s *Server) HandleGetPayload(w http.ResponseWriter, r *http.Request) {
 	bodyBytes, err := io.ReadAll(r.Body)
 	if err != nil {
 		span.SetStatus(codes.Error, err.Error())
-		log.Error().Err(err).Time("currentTime", time.Now().UTC()).Msg("could not read registration")
-		respondError(getPayloadCtx, span, getPayload, w, toErrorResp(http.StatusInternalServerError, "could not read registration"), &log, s.tracer, receivedAt)
+		log.Error().Err(err).Time("currentTime", time.Now().UTC()).Msg("could not read getPayload request bytes")
+		respondError(getPayloadCtx, span, getPayload, w, toErrorResp(http.StatusInternalServerError, "could not read getPayload request bytes"), &log, s.tracer, receivedAt)
 		return
 	}
 	signedBlindedBeaconBlock := new(common.VersionedSignedBlindedBeaconBlock)
@@ -1088,8 +1088,8 @@ func (s *Server) HandleGetPayloadV2(w http.ResponseWriter, r *http.Request) {
 	bodyBytes, err := io.ReadAll(r.Body)
 	if err != nil {
 		span.SetStatus(codes.Error, err.Error())
-		log.Error().Err(err).Time("currentTime", time.Now().UTC()).Msg("could not read registration")
-		respondError(getPayloadCtx, span, getPayloadV2, w, toErrorResp(http.StatusInternalServerError, "could not read payload"), &log, s.tracer, receivedAt)
+		log.Error().Err(err).Time("currentTime", time.Now().UTC()).Msg("could not read getPayloadV2 request bytes")
+		respondError(getPayloadCtx, span, getPayloadV2, w, toErrorResp(http.StatusInternalServerError, "could not read getPayloadV2 request bytes"), &log, s.tracer, receivedAt)
 		return
 	}
 	signedBlindedBeaconBlock := new(common.VersionedSignedBlindedBeaconBlock)

--- a/server.go
+++ b/server.go
@@ -578,35 +578,42 @@ func (s *Server) HandleRegistration(w http.ResponseWriter, r *http.Request) {
 	handleRegistrationSpan.SetAttributes(
 		attribute.Bool("proposerMevProtect", hasProposerMevProtect),
 	)
-	bodyBytes, err := io.ReadAll(r.Body)
+	bodyBytes, err := io.ReadAll(io.LimitReader(r.Body, maxRegistrationPayloadBytes+1))
 	if err != nil {
 		handleRegistrationSpan.SetStatus(codes.Error, err.Error())
 		log.Error().Err(err).Msg("could not read registration")
 		respondError(handleRegistrationCtx, handleRegistrationSpan, registration, w, toErrorResp(http.StatusInternalServerError, "could not read registration"), &log, s.tracer, receivedAt)
 		return
 	}
+	if len(bodyBytes) > maxRegistrationPayloadBytes {
+		handleRegistrationSpan.SetStatus(codes.Error, "registration payload too large")
+		log.Error().Int("payloadBytes", len(bodyBytes)).Msg("registration payload too large")
+		respondError(handleRegistrationCtx, handleRegistrationSpan, registration, w, toErrorResp(http.StatusRequestEntityTooLarge, "registration payload too large"), &log, s.tracer, receivedAt)
+		return
+	}
 	handleRegistrationSpan.AddEvent("handleRegistration- svcRegisterValidator")
-	go func() {
-		_, err := s.svc.RegisterValidator(handleRegistrationCtx, &log, outgoingCtx, &RegistrationParams{
-			ReceivedAt:         receivedAt,
-			Payload:            bodyBytes,
-			ClientIP:           clientIP,
-			AuthHeader:         authHeader,
-			ValidatorID:        validatorID,
-			AccountID:          accountID,
-			ComplianceList:     complianceList,
-			ProposerMevProtect: hasProposerMevProtect,
-			SkipOptimism:       isSkipOptimism,
-		})
-		if err != nil {
-			handleRegistrationSpan.SetStatus(codes.Error, err.Error())
-			handleRegistrationSpan.SetAttributes(
-				attribute.String("error", err.Error()),
-			)
-			log.Error().Err(err).Msg("error in RegisterValidator")
+	// enqueues for asynchronous forwarding; only fails when the queue is full
+	if _, err := s.svc.RegisterValidator(handleRegistrationCtx, &log, outgoingCtx, &RegistrationParams{
+		ReceivedAt:         receivedAt,
+		Payload:            bodyBytes,
+		ClientIP:           clientIP,
+		AuthHeader:         authHeader,
+		ValidatorID:        validatorID,
+		AccountID:          accountID,
+		ComplianceList:     complianceList,
+		ProposerMevProtect: hasProposerMevProtect,
+		SkipOptimism:       isSkipOptimism,
+	}); err != nil {
+		handleRegistrationSpan.SetStatus(codes.Error, err.Error())
+		handleRegistrationSpan.SetAttributes(
+			attribute.String("error", err.Error()),
+		)
+		log.Error().Err(err).Msg("error in RegisterValidator")
+		if errResp, ok := err.(*ErrorResp); ok && errResp.Code == http.StatusServiceUnavailable {
+			respondError(handleRegistrationCtx, handleRegistrationSpan, registration, w, errResp, &log, s.tracer, receivedAt)
 			return
 		}
-	}()
+	}
 
 	if err := respondOK(handleRegistrationCtx, handleRegistrationSpan, registration, w, struct{}{}, &log, s.tracer, false, receivedAt); err == nil {
 		success = true

--- a/server.go
+++ b/server.go
@@ -592,7 +592,8 @@ func (s *Server) HandleRegistration(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	handleRegistrationSpan.AddEvent("handleRegistration- svcRegisterValidator")
-	// enqueues for asynchronous forwarding; only fails when the queue is full
+	// enqueues for asynchronous forwarding (drop-oldest under overload), so
+	// registration errors are never surfaced to the client
 	if _, err := s.svc.RegisterValidator(handleRegistrationCtx, &log, outgoingCtx, &RegistrationParams{
 		ReceivedAt:         receivedAt,
 		Payload:            bodyBytes,
@@ -609,10 +610,6 @@ func (s *Server) HandleRegistration(w http.ResponseWriter, r *http.Request) {
 			attribute.String("error", err.Error()),
 		)
 		log.Error().Err(err).Msg("Error in RegisterValidator")
-		if errResp, ok := err.(*ErrorResp); ok && errResp.Code == http.StatusServiceUnavailable {
-			respondError(handleRegistrationCtx, handleRegistrationSpan, registration, w, errResp, &log, s.tracer, receivedAt)
-			return
-		}
 	}
 
 	if err := respondOK(handleRegistrationCtx, handleRegistrationSpan, registration, w, struct{}{}, &log, s.tracer, false, receivedAt); err == nil {

--- a/server.go
+++ b/server.go
@@ -591,6 +591,17 @@ func (s *Server) HandleRegistration(w http.ResponseWriter, r *http.Request) {
 		respondError(handleRegistrationCtx, handleRegistrationSpan, registration, w, toErrorResp(http.StatusRequestEntityTooLarge, "registration payload too large"), &log, s.tracer, receivedAt)
 		return
 	}
+
+	// Some clients send zero-length registration
+	// Reject without forwarding, mirroring the MEV	Relay's empty-body response
+	// (mev-boost-relay handleRegisterValidator), and keep the dropped counter clean
+	if len(bodyBytes) == 0 {
+		handleRegistrationSpan.AddEvent("handleRegistration- emptyPayloadRejected")
+		log.Warn().Msg("empty body received on registerValidator")
+		respondError(handleRegistrationCtx, handleRegistrationSpan, registration, w, toErrorResp(http.StatusBadRequest, "empty json/ssz body"), &log, s.tracer, receivedAt)
+		return
+	}
+
 	handleRegistrationSpan.AddEvent("handleRegistration- svcRegisterValidator")
 	// enqueues for asynchronous forwarding (drop-oldest under overload), so
 	// registration errors are never surfaced to the client

--- a/server_test.go
+++ b/server_test.go
@@ -211,6 +211,36 @@ func TestServer_HandleRegistration(t *testing.T) {
 			assert.Equal(t, tc.expectedCode, rr.Code)
 		})
 	}
+
+	t.Run("Empty registration body gets 400 without forwarding, mirroring the relay", func(t *testing.T) {
+		forwarded := false
+		server := &Server{
+			svc: &MockService{
+				logger: zap.NewNop(),
+				RegisterValidatorFunc: func(ctx context.Context, outgoingctx context.Context, in *RegistrationParams) (interface{}, error) {
+					forwarded = true
+					return nil, nil
+				},
+			},
+			logger: zerolog.Nop(),
+			tracer: noop.NewTracerProvider().Tracer("test"),
+			accountsLists: &AccountsLists{
+				AccountIDToInfo:   make(map[string]*AccountInfo),
+				AccountNameToInfo: make(map[AccountName]*AccountInfo),
+			},
+			performanceStats: stat.NewPerformanceStats(),
+		}
+		req, err := http.NewRequest("POST", "/eth/v1/builder/validators", bytes.NewBuffer(nil))
+		if err != nil {
+			t.Fatal(err)
+		}
+		rr := httptest.NewRecorder()
+		h := server.Middleware(http.HandlerFunc(server.HandleRegistration))
+		h.ServeHTTP(rr, req)
+		assert.Equal(t, http.StatusBadRequest, rr.Code)
+		assert.Contains(t, rr.Body.String(), "empty json/ssz body")
+		assert.False(t, forwarded, "empty registration must not be forwarded to relays")
+	})
 }
 
 func TestServer_HandleGetHeader(t *testing.T) {

--- a/server_test.go
+++ b/server_test.go
@@ -163,7 +163,7 @@ func TestServer_HandleRegistration(t *testing.T) {
 			},
 			expectedCode: http.StatusOK,
 		},
-		"When registration failed": {
+		"When registration forwarding fails the client still gets OK": {
 			requestBody: []byte(`{"key": "value"}`),
 			url:         "/eth/v1/builder/validators",
 			mockService: &MockService{
@@ -172,7 +172,18 @@ func TestServer_HandleRegistration(t *testing.T) {
 					return nil, toErrorResp(http.StatusInternalServerError, "")
 				},
 			},
-			expectedCode: http.StatusUnauthorized,
+			expectedCode: http.StatusOK,
+		},
+		"When registration queue is full": {
+			requestBody: []byte(`{"key": "value"}`),
+			url:         "/eth/v1/builder/validators",
+			mockService: &MockService{
+				logger: zap.NewNop(),
+				RegisterValidatorFunc: func(ctx context.Context, outgoingctx context.Context, in *RegistrationParams) (interface{}, error) {
+					return nil, toErrorResp(http.StatusServiceUnavailable, "registration queue is full")
+				},
+			},
+			expectedCode: http.StatusServiceUnavailable,
 		},
 	}
 

--- a/server_test.go
+++ b/server_test.go
@@ -174,7 +174,7 @@ func TestServer_HandleRegistration(t *testing.T) {
 			},
 			expectedCode: http.StatusOK,
 		},
-		"When registration queue is full": {
+		"Service errors are never surfaced to the client": {
 			requestBody: []byte(`{"key": "value"}`),
 			url:         "/eth/v1/builder/validators",
 			mockService: &MockService{
@@ -183,7 +183,7 @@ func TestServer_HandleRegistration(t *testing.T) {
 					return nil, toErrorResp(http.StatusServiceUnavailable, "registration queue is full")
 				},
 			},
-			expectedCode: http.StatusServiceUnavailable,
+			expectedCode: http.StatusOK,
 		},
 	}
 

--- a/service.go
+++ b/service.go
@@ -116,6 +116,7 @@ type Service struct {
 	regForwardedOK                atomic.Int64 // registrations acknowledged by a relay since the last monitor tick
 	regForwardFailedAttempts      atomic.Int64 // failed forward attempts since the last monitor tick
 	regForwardDropped             atomic.Int64 // registrations abandoned after retries since the last monitor tick
+	regSucceededAfterRetry        atomic.Int64 // registrations that needed >=1 retry to be acknowledged, since the last monitor tick
 
 	secretKey            *bls.SecretKey
 	publicKey            phase0.BLSPubKey

--- a/service.go
+++ b/service.go
@@ -113,6 +113,9 @@ type Service struct {
 	registrationWorkersOnce       sync.Once
 	regInFlightBytes              *semaphore.Weighted
 	regInFlightSlots              chan struct{}
+	regForwardedOK                atomic.Int64 // registrations acknowledged by a relay since the last monitor tick
+	regForwardFailedAttempts      atomic.Int64 // failed forward attempts since the last monitor tick
+	regForwardDropped             atomic.Int64 // registrations abandoned after retries since the last monitor tick
 
 	secretKey            *bls.SecretKey
 	publicKey            phase0.BLSPubKey

--- a/service.go
+++ b/service.go
@@ -32,6 +32,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	otelcodes "go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
+	"golang.org/x/sync/semaphore"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
@@ -110,6 +111,8 @@ type Service struct {
 	registrationQueue             chan *registrationTask
 	registrationQueueBytes        atomic.Int64
 	registrationWorkersOnce       sync.Once
+	regInFlightBytes              *semaphore.Weighted
+	regInFlightSlots              chan struct{}
 
 	secretKey            *bls.SecretKey
 	publicKey            phase0.BLSPubKey

--- a/service.go
+++ b/service.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	eth2Api "github.com/attestantio/go-eth2-client/api"
@@ -106,6 +107,9 @@ type Service struct {
 	registrationClients           []*common.ParentClient
 	currentRegistrationRelayIndex int
 	registrationRelayMutex        sync.Mutex
+	registrationQueue             chan *registrationTask
+	registrationQueueBytes        atomic.Int64
+	registrationWorkersOnce       sync.Once
 
 	secretKey            *bls.SecretKey
 	publicKey            phase0.BLSPubKey

--- a/service_test.go
+++ b/service_test.go
@@ -14,6 +14,7 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -63,61 +64,91 @@ const (
 	TestAuthHeader = "NzM2NWJiYzgtMTBkNS00OGZjLTk5NGQtNjFlODQzYjE0OGNjOmZiMmQ3NWU5LWIwY2YtNDIyMS1hZjMxLTZjYTYwOGYyZTExNA=="
 )
 
-func TestService_RegisterValidator(t *testing.T) {
-	tests := map[string]struct {
-		f               func(ctx context.Context, req *relaygrpc.RegisterValidatorRequest, opts ...grpc.CallOption) (*relaygrpc.RegisterValidatorResponse, error)
-		expectedSuccess any
-		expectedErr     *ErrorResp
-	}{
-		"If registerValidator succeeded ": {
-			f: func(ctx context.Context, req *relaygrpc.RegisterValidatorRequest, opts ...grpc.CallOption) (*relaygrpc.RegisterValidatorResponse, error) {
-				return &relaygrpc.RegisterValidatorResponse{Code: 0, Message: "success"}, nil
-			},
-			expectedSuccess: struct{}{},
-			expectedErr:     nil,
-		},
-		"If registerValidator returns error": {
-			f: func(ctx context.Context, req *relaygrpc.RegisterValidatorRequest, opts ...grpc.CallOption) (*relaygrpc.RegisterValidatorResponse, error) {
-				return nil, fmt.Errorf("relays returned error")
-			},
-			expectedErr: toErrorResp(http.StatusInternalServerError, "relays returned error"),
-		},
-		"If registerValidator returns empty output": {
-			f: func(ctx context.Context, req *relaygrpc.RegisterValidatorRequest, opts ...grpc.CallOption) (*relaygrpc.RegisterValidatorResponse, error) {
-				return nil, nil
-			},
-			expectedErr: toErrorResp(http.StatusInternalServerError, "empty response from relay"),
-		},
-		"If registerValidator returns error output": {
-			f: func(ctx context.Context, req *relaygrpc.RegisterValidatorRequest, opts ...grpc.CallOption) (*relaygrpc.RegisterValidatorResponse, error) {
-				return &relaygrpc.RegisterValidatorResponse{Code: 2, Message: "failed"}, nil
-			},
-			expectedErr: toErrorResp(http.StatusInternalServerError, "relay returned failure response code 2"),
-		},
+func newRegistrationTestService(f func(ctx context.Context, req *relaygrpc.RegisterValidatorRequest, opts ...grpc.CallOption) (*relaygrpc.RegisterValidatorResponse, error)) *Service {
+	c := &common.Client{RelayClient: &mockRelayClient{RegisterValidatorFunc: f}}
+	pc := &common.ParentClient{
+		SafeClient: c,
 	}
+	return &Service{
+		logger:              zerolog.Nop(),
+		clients:             []*common.ParentClient{pc},
+		registrationClients: []*common.ParentClient{pc},
+		tracer:              noop.NewTracerProvider().Tracer("test"),
+		fluentD:             fluentstats.NewStats(true, "0.0.0.0:24224"),
+	}
+}
 
-	for testName, tt := range tests {
-		t.Run(testName, func(t *testing.T) {
-			c := &common.Client{RelayClient: &mockRelayClient{RegisterValidatorFunc: tt.f}}
-			pc := &common.ParentClient{
-				SafeClient: c,
-				FastClient: c,
-			}
-			s := &Service{
-				logger:              zerolog.Nop(),
-				clients:             []*common.ParentClient{pc},
-				registrationClients: []*common.ParentClient{pc},
-				tracer:              noop.NewTracerProvider().Tracer("test"),
-				fluentD:             fluentstats.NewStats(true, "0.0.0.0:24224"),
-			}
-			got, err := s.RegisterValidator(context.Background(), &zerolog.Logger{}, context.Background(), &RegistrationParams{})
-			if err == nil {
-				assert.Equal(t, tt.expectedSuccess, got)
-				return
-			}
-			assert.Equal(t, tt.expectedErr.Error(), err.Error())
+func TestService_RegisterValidator(t *testing.T) {
+	t.Run("enqueues and forwards to the relay", func(t *testing.T) {
+		forwarded := make(chan *relaygrpc.RegisterValidatorRequest, 1)
+		s := newRegistrationTestService(func(ctx context.Context, req *relaygrpc.RegisterValidatorRequest, opts ...grpc.CallOption) (*relaygrpc.RegisterValidatorResponse, error) {
+			forwarded <- req
+			return &relaygrpc.RegisterValidatorResponse{Code: 0, Message: "success"}, nil
 		})
-	}
+
+		got, err := s.RegisterValidator(context.Background(), &zerolog.Logger{}, context.Background(), &RegistrationParams{Payload: []byte("registration")})
+		assert.Nil(t, err)
+		assert.Equal(t, struct{}{}, got)
+
+		select {
+		case req := <-forwarded:
+			assert.Equal(t, []byte("registration"), req.Payload)
+		case <-time.After(2 * time.Second):
+			t.Fatal("registration was not forwarded to the relay")
+		}
+		assert.Equal(t, int64(0), s.registrationQueueBytes.Load())
+	})
+
+	t.Run("retries transient failures then succeeds", func(t *testing.T) {
+		var attempts atomic.Int64
+		forwarded := make(chan struct{}, 1)
+		s := newRegistrationTestService(func(ctx context.Context, req *relaygrpc.RegisterValidatorRequest, opts ...grpc.CallOption) (*relaygrpc.RegisterValidatorResponse, error) {
+			if attempts.Add(1) == 1 {
+				return nil, fmt.Errorf("relays returned error")
+			}
+			forwarded <- struct{}{}
+			return &relaygrpc.RegisterValidatorResponse{Code: 0, Message: "success"}, nil
+		})
+
+		_, err := s.RegisterValidator(context.Background(), &zerolog.Logger{}, context.Background(), &RegistrationParams{Payload: []byte("registration")})
+		assert.Nil(t, err)
+
+		select {
+		case <-forwarded:
+			assert.Equal(t, int64(2), attempts.Load())
+		case <-time.After(2*regForwardRetryBackoff + 2*time.Second):
+			t.Fatal("registration was not retried")
+		}
+	})
+
+	t.Run("does not retry permanent relay rejections", func(t *testing.T) {
+		var attempts atomic.Int64
+		done := make(chan struct{}, regForwardMaxAttempts)
+		s := newRegistrationTestService(func(ctx context.Context, req *relaygrpc.RegisterValidatorRequest, opts ...grpc.CallOption) (*relaygrpc.RegisterValidatorResponse, error) {
+			attempts.Add(1)
+			done <- struct{}{}
+			return &relaygrpc.RegisterValidatorResponse{Code: 2, Message: "failed"}, nil
+		})
+
+		_, err := s.RegisterValidator(context.Background(), &zerolog.Logger{}, context.Background(), &RegistrationParams{Payload: []byte("registration")})
+		assert.Nil(t, err)
+
+		<-done
+		time.Sleep(2 * regForwardRetryBackoff)
+		assert.Equal(t, int64(1), attempts.Load())
+	})
+
+	t.Run("rejects when queue byte limit is reached", func(t *testing.T) {
+		s := newRegistrationTestService(nil)
+		s.registrationQueueBytes.Store(regQueueMaxBytes)
+
+		_, err := s.RegisterValidator(context.Background(), &zerolog.Logger{}, context.Background(), &RegistrationParams{Payload: []byte("registration")})
+		assert.NotNil(t, err)
+		errResp, ok := err.(*ErrorResp)
+		assert.True(t, ok)
+		assert.Equal(t, http.StatusServiceUnavailable, errResp.Code)
+		assert.Equal(t, int64(regQueueMaxBytes), s.registrationQueueBytes.Load())
+	})
 }
 
 func TestService_GetHeader(t *testing.T) {
@@ -177,7 +208,6 @@ func TestService_GetHeader(t *testing.T) {
 			c := &common.Client{RelayClient: &mockRelayClient{}}
 			pc := &common.ParentClient{
 				SafeClient: c,
-				FastClient: c,
 			}
 			opts = append(opts, WithClients([]*common.ParentClient{pc}))
 			opts = append(opts, WithSvcTracer(noop.NewTracerProvider().Tracer("test")))
@@ -239,7 +269,6 @@ func TestService_getPayload(t *testing.T) {
 			c := &common.Client{RelayClient: &mockRelayClient{GetPayloadFunc: tt.f}}
 			pc := &common.ParentClient{
 				SafeClient: c,
-				FastClient: c,
 			}
 			svcOpts = append(svcOpts, WithClients([]*common.ParentClient{pc}))
 			svcOpts = append(svcOpts, WithSvcTracer(noop.NewTracerProvider().Tracer("test")))
@@ -634,11 +663,11 @@ func TestService_StreamHeaderAndGetMethod(t *testing.T) {
 	defer conn.Close()
 	dSvc := NewDataService(WithDataSvcLogger(zerolog.Nop()))
 	svcOpts := make([]ServiceOption, 0)
-	c := common.NewParentClient(lis.Addr().String(), conn, lis.Addr().String(), conn, "")
+	c := common.NewParentClient(lis.Addr().String(), conn, "")
 	clients := []*common.ParentClient{c}
-	sc := common.NewParentClient(lis.Addr().String(), conn, lis.Addr().String(), conn, "")
+	sc := common.NewParentClient(lis.Addr().String(), conn, "")
 	streamingClients := []*common.ParentClient{sc}
-	registrationClient := common.NewParentClient(lis.Addr().String(), conn, lis.Addr().String(), conn, "")
+	registrationClient := common.NewParentClient(lis.Addr().String(), conn, "")
 	registrationClients := []*common.ParentClient{registrationClient}
 	tracer := noop.NewTracerProvider().Tracer("test")
 	svcOpts = append(svcOpts, WithSvcLogger(l))
@@ -655,7 +684,7 @@ func TestService_StreamHeaderAndGetMethod(t *testing.T) {
 	service.accountsLists = &AccountsLists{AccountIDToInfo: make(map[string]*AccountInfo),
 		AccountNameToInfo: make(map[AccountName]*AccountInfo)}
 	go func() {
-		if _, err := service.StreamHeader(ctx, c.FastClient, c); err != nil {
+		if _, err := service.StreamHeader(ctx, c.SafeClient, c); err != nil {
 			panic(err)
 		}
 	}()
@@ -1117,7 +1146,6 @@ func TestGetPayloadWithRetry(t *testing.T) {
 			client := &common.Client{URL: "", NodeID: "", RelayClient: mockClient}
 			parentClient := &common.ParentClient{
 				SafeClient: client,
-				FastClient: client,
 			}
 			service := &Service{
 				clients: []*common.ParentClient{parentClient},

--- a/service_test.go
+++ b/service_test.go
@@ -138,15 +138,56 @@ func TestService_RegisterValidator(t *testing.T) {
 		assert.Equal(t, int64(1), attempts.Load())
 	})
 
-	t.Run("rejects when queue byte limit is reached", func(t *testing.T) {
+	t.Run("evicts oldest when task capacity is reached", func(t *testing.T) {
 		s := newRegistrationTestService(nil)
+		// disarm the worker pool and use a tiny queue so eviction is deterministic
+		s.registrationWorkersOnce.Do(func() {})
+		s.registrationQueue = make(chan *registrationTask, 2)
+
+		for _, payload := range []string{"first", "second", "third"} {
+			got, err := s.RegisterValidator(context.Background(), &zerolog.Logger{}, context.Background(), &RegistrationParams{Payload: []byte(payload)})
+			assert.Nil(t, err)
+			assert.Equal(t, struct{}{}, got)
+		}
+
+		// "first" (the oldest) was evicted to admit "third"
+		assert.Equal(t, 2, len(s.registrationQueue))
+		assert.Equal(t, []byte("second"), (<-s.registrationQueue).req.Payload)
+		assert.Equal(t, []byte("third"), (<-s.registrationQueue).req.Payload)
+		assert.Equal(t, int64(len("second")+len("third")), s.registrationQueueBytes.Load())
+	})
+
+	t.Run("evicts oldest when byte limit is reached", func(t *testing.T) {
+		s := newRegistrationTestService(nil)
+		s.registrationWorkersOnce.Do(func() {})
+		s.registrationQueue = make(chan *registrationTask, 4)
+
+		_, err := s.RegisterValidator(context.Background(), &zerolog.Logger{}, context.Background(), &RegistrationParams{Payload: make([]byte, 100)})
+		assert.Nil(t, err)
+		// pretend the queue already holds the byte cap
 		s.registrationQueueBytes.Store(regQueueMaxBytes)
 
-		_, err := s.RegisterValidator(context.Background(), &zerolog.Logger{}, context.Background(), &RegistrationParams{Payload: []byte("registration")})
-		assert.NotNil(t, err)
-		errResp, ok := err.(*ErrorResp)
-		assert.True(t, ok)
-		assert.Equal(t, http.StatusServiceUnavailable, errResp.Code)
+		got, err := s.RegisterValidator(context.Background(), &zerolog.Logger{}, context.Background(), &RegistrationParams{Payload: make([]byte, 50)})
+		assert.Nil(t, err)
+		assert.Equal(t, struct{}{}, got)
+
+		// the 100-byte head was evicted to fit the 50-byte newcomer under the cap
+		assert.Equal(t, 1, len(s.registrationQueue))
+		assert.Equal(t, 50, len((<-s.registrationQueue).req.Payload))
+		assert.Equal(t, int64(regQueueMaxBytes-100+50), s.registrationQueueBytes.Load())
+	})
+
+	t.Run("drops the new registration when nothing can be evicted", func(t *testing.T) {
+		s := newRegistrationTestService(nil)
+		s.registrationWorkersOnce.Do(func() {})
+		s.registrationQueue = make(chan *registrationTask, 4)
+		// over byte cap with an empty queue: nothing to evict, newcomer is shed
+		s.registrationQueueBytes.Store(regQueueMaxBytes)
+
+		got, err := s.RegisterValidator(context.Background(), &zerolog.Logger{}, context.Background(), &RegistrationParams{Payload: []byte("registration")})
+		assert.Nil(t, err)
+		assert.Equal(t, struct{}{}, got) // client still sees success
+		assert.Equal(t, 0, len(s.registrationQueue))
 		assert.Equal(t, int64(regQueueMaxBytes), s.registrationQueueBytes.Load())
 	})
 }

--- a/service_test.go
+++ b/service_test.go
@@ -97,6 +97,9 @@ func TestService_RegisterValidator(t *testing.T) {
 			t.Fatal("registration was not forwarded to the relay")
 		}
 		assert.Equal(t, int64(0), s.registrationQueueBytes.Load())
+		assert.Eventually(t, func() bool {
+			return s.regForwardedOK.Load() == 1 && s.regForwardFailedAttempts.Load() == 0
+		}, time.Second, 10*time.Millisecond, "success counter was not incremented")
 	})
 
 	t.Run("retries transient failures then succeeds", func(t *testing.T) {
@@ -119,6 +122,9 @@ func TestService_RegisterValidator(t *testing.T) {
 		case <-time.After(2*regForwardRetryBackoff + 2*time.Second):
 			t.Fatal("registration was not retried")
 		}
+		assert.Eventually(t, func() bool {
+			return s.regForwardedOK.Load() == 1 && s.regForwardFailedAttempts.Load() == 1 && s.regForwardDropped.Load() == 0
+		}, time.Second, 10*time.Millisecond, "retry counters were not incremented")
 	})
 
 	t.Run("does not retry permanent relay rejections", func(t *testing.T) {

--- a/service_test.go
+++ b/service_test.go
@@ -123,7 +123,8 @@ func TestService_RegisterValidator(t *testing.T) {
 			t.Fatal("registration was not retried")
 		}
 		assert.Eventually(t, func() bool {
-			return s.regForwardedOK.Load() == 1 && s.regForwardFailedAttempts.Load() == 1 && s.regForwardDropped.Load() == 0
+			return s.regForwardedOK.Load() == 1 && s.regForwardFailedAttempts.Load() == 1 &&
+				s.regForwardDropped.Load() == 0 && s.regSucceededAfterRetry.Load() == 1
 		}, time.Second, 10*time.Millisecond, "retry counters were not incremented")
 	})
 

--- a/service_test.go
+++ b/service_test.go
@@ -138,6 +138,28 @@ func TestService_RegisterValidator(t *testing.T) {
 		assert.Equal(t, int64(1), attempts.Load())
 	})
 
+	t.Run("forwards a burst concurrently, not serially", func(t *testing.T) {
+		const burst = 64 // far above the old fixed pool size of 16
+		var inFlight atomic.Int64
+		release := make(chan struct{})
+		s := newRegistrationTestService(func(ctx context.Context, req *relaygrpc.RegisterValidatorRequest, opts ...grpc.CallOption) (*relaygrpc.RegisterValidatorResponse, error) {
+			inFlight.Add(1)
+			<-release // hold every call open so concurrency is observable
+			return &relaygrpc.RegisterValidatorResponse{Code: 0, Message: "success"}, nil
+		})
+
+		for range burst {
+			_, err := s.RegisterValidator(context.Background(), &zerolog.Logger{}, context.Background(), &RegistrationParams{Payload: []byte("registration")})
+			assert.Nil(t, err)
+		}
+
+		// every registration of the burst must be in flight simultaneously
+		assert.Eventually(t, func() bool {
+			return inFlight.Load() == burst
+		}, 2*time.Second, 10*time.Millisecond, "burst was not forwarded concurrently: %d in flight", inFlight.Load())
+		close(release)
+	})
+
 	t.Run("evicts oldest when task capacity is reached", func(t *testing.T) {
 		s := newRegistrationTestService(nil)
 		// disarm the worker pool and use a tiny queue so eviction is deterministic


### PR DESCRIPTION
## Summary

RProxy OOMs (4GB container limit) traced via pprof to validator-registration forwarding:
`HandleRegistration` read unbounded bodies, spawned an unbounded goroutine per request, and
forwarded over gRPC with `context.Background()` — no deadline. When the registration relays
were slow, marshaled payloads accumulated in gRPC client transport buffers during a burst, killing the process (and dropping everything in flight).

---

## ✅ I have completed the following steps:

* [ ] Run `make lint`
* [ ] Run `make test`
* [ ] Run `go mod tidy`
* [ ] Added tests (if applicable)
