### PR TITLE
MEV-1989/RelayProxy-fix-Uptrace-spans-not-showing-when-searching-by-slot

### DIFF
--- a/server.go
+++ b/server.go
@@ -602,6 +602,7 @@ func (s *Server) HandleGetHeader(w http.ResponseWriter, r *http.Request) {
 
 	receivedAt := time.Now().UTC()
 	slot := chi.URLParam(r, "slot")
+	slotInt, _ := fastParseUint(slot)
 	parentHash := chi.URLParam(r, "parent_hash")
 	pubKey := chi.URLParam(r, "pubkey")
 	parsedURL := r.Context().Value(keyParsedURL).(*url.URL)
@@ -651,7 +652,7 @@ func (s *Server) HandleGetHeader(w http.ResponseWriter, r *http.Request) {
 			attribute.String("method", getHeader),
 			attribute.String("key", "slot-"+slot+"-parentHash-"+parentHash),
 			attribute.Int64("receivedAt", receivedAt.UnixMilli()),
-			attribute.String("slot", slot),
+			attribute.Int64("slot", int64(slotInt)),
 			attribute.String("headerTimeoutStr", headerTimeoutStr),
 		)
 		if onHeaderDeliveredParams != nil {


### PR DESCRIPTION
The handleGetHeader-start span sets the slot attribute as a string while other spans (e.g. RProxy's own handleGetPayloadV2-start) use an int64, so Uptrace's slot filter only matches the int-typed column and silently misses these spans.

## 📝 Summary

<!--- A general summary of your changes -->

## 💡 Motivation and Context

<!--- (Optional) Why is this change required? What problem does it solve? Remove this section if not applicable. -->

---

## ✅ I have completed the following steps:

* [ ] Run `make lint`
* [ ] Run `make test`
* [ ] Run `go mod tidy`
* [ ] Added tests (if applicable)
